### PR TITLE
[WIP] RAINCATCH-956 logger interface

### DIFF
--- a/cloud/logger-debug/.gitignore
+++ b/cloud/logger-debug/.gitignore
@@ -1,0 +1,5 @@
+# generated code
+src/**/*.js
+src/**/*.map
+test/**/*.js
+test/**/*.map

--- a/cloud/logger-debug/README.md
+++ b/cloud/logger-debug/README.md
@@ -1,0 +1,13 @@
+# RainCatcher Logger
+
+
+Based of example base module located in `/raincatcher-core/examples/base`
+
+//TODO
+Raincatcher Logging standards
+
+//TODO
+module description
+
+//TODO
+module usage

--- a/cloud/logger-debug/index.js
+++ b/cloud/logger-debug/index.js
@@ -1,0 +1,10 @@
+/**
+ * This file is only a proxy for src/index, so it can be required by either
+ * JavaScript or TypeScript code.
+ *
+ * If running code through `ts-node` it'll require src/index.ts. If running from
+ * a nodejs environment it'll require src/index.js,
+ * which is generated via compilation.
+ */
+
+module.exports = require('./src/');

--- a/cloud/logger-debug/package.json
+++ b/cloud/logger-debug/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@raincatcher/logger",
+  "version": "0.0.1",
+  "description": "RainCatcher logger utility",
+  "types": "src/index.ts",
+  "author": "feedhenry-raincatcher@redhat.com",
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "del src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
+    "build": "tsc",
+    "test": "nyc mocha",
+    "prepublish": "npm run clean && npm run build"
+  },
+  "nyc": {
+    "include": [
+      "src/**/*.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "check-coverage": true,
+    "lines": 75,
+    "functions": 100,
+    "branches": 80
+  },
+  "devDependencies": {
+    "@types/mocha": "^2.2.41",
+    "@types/node": "^7.0.29",
+    "@types/debug": "0.0.29",
+    "del-cli": "^1.0.0",
+    "mocha": "^3.4.2",
+    "nyc": "^11.0.1",
+    "source-map-support": "^0.4.15",
+    "ts-node": "^3.0.4",
+    "typescript": "^2.3.4"
+  },
+  "dependencies": {
+    "debug": "^2.6.8"
+  }
+}

--- a/cloud/logger-debug/src/Logger.ts
+++ b/cloud/logger-debug/src/Logger.ts
@@ -1,0 +1,15 @@
+interface Logger {
+  debug(message: string, data?: any, source?: string, tags?: string[]): void;
+  error(message: string, data?: any, source?: string, tags?: string[]): void;
+  info(message: string, data?: any, source?: string, tags?: string[]): void;
+  warn(message: string, data?: any, source?: string, tags?: string[]): void;
+}
+
+export enum LOG_LEVEL {
+  DEBUG,
+  ERROR,
+  INFO,
+  WARN
+}
+
+export default Logger;

--- a/cloud/logger-debug/src/index.ts
+++ b/cloud/logger-debug/src/index.ts
@@ -1,0 +1,63 @@
+import * as debug from 'debug';
+import Logger, {LOG_LEVEL} from './Logger';
+
+/**
+ * Raincatcher logger implementation, can take a different logger at construction time.
+ */
+export default class LoggerImpl implements Logger {
+
+  public static getInstance(): LoggerImpl {
+    return LoggerImpl.instance;
+  }
+
+  private static instance: LoggerImpl = new LoggerImpl();
+  private namespace: string;
+  private logger: any;
+
+  constructor() {
+    if (LoggerImpl.instance) {
+      throw new Error('Error: Instantiation failed: Use LoggerImpl.getInstance() instead of new().');
+    } else {
+      LoggerImpl.instance = this;
+    }
+  }
+
+  public setNamespace( namespace: string) {
+    this.namespace = namespace;
+    this.logger = debug(`${namespace}:error:`);
+  }
+
+  public debug(message: string): void {
+    this.logger(`debug:${message}`);
+  }
+
+  public error(message: string): void {
+    this.logger(`error:${message}`);
+  }
+
+  public info(message: string): void {
+    this.logger(`info:${message}`);
+  }
+
+  public warn(message: string): void {
+    this.logger(`warning:${message}`);
+  }
+
+  public log(level: LOG_LEVEL, message: string) {
+    switch (+level) {
+      case LOG_LEVEL.DEBUG:
+        this.debug(message);
+        break;
+      case LOG_LEVEL.ERROR:
+        this.error(message);
+        break;
+      case LOG_LEVEL.INFO:
+        this.info(message);
+        break;
+      case LOG_LEVEL.WARN:
+        this.warn(message);
+        break;
+      default:
+    }
+  }
+}

--- a/cloud/logger-debug/test/RaincatcherBase.ts
+++ b/cloud/logger-debug/test/RaincatcherBase.ts
@@ -1,0 +1,30 @@
+import LoggerImpl from '../src';
+import baseSuite from './index';
+
+/**
+ * Auxiliary class so we can have a parameter-less constructor
+ * Could have stubs/spies, etc.
+ */
+class NoopRaincatcherBase extends LoggerImpl {
+  constructor() {
+    super();
+  }
+}
+
+describe('RaincatcherBase', function() {
+  // Use regular variables instead of mocha's `this` so it's strongly typed
+  let subject: LoggerImpl;
+  beforeEach(function() {
+    subject = LoggerImpl.getInstance();
+    subject.setNamespace('NoopRaincatcherBase');
+  });
+
+  describe('#customFunction', function() {
+    it('should add the supplied prefix', function() {
+      subject.debug('asdasd');
+    });
+  });
+
+  // Delegate to public interface suite
+  baseSuite();
+});

--- a/cloud/logger-debug/test/index.ts
+++ b/cloud/logger-debug/test/index.ts
@@ -1,0 +1,22 @@
+/// <reference types="mocha" />
+import * as debug from 'debug';
+debug.enable('*');
+
+import LoggerImpl from '../src';
+
+function baseSuite() {
+  describe('Base', function() {
+    let subject: LoggerImpl;
+    beforeEach(function() {
+      subject =  LoggerImpl.getInstance();
+      subject.setNamespace('base siute');
+    });
+    describe('#foo()', function() {
+      it('should receive a string param', function() {
+        subject.error('hello');
+      });
+    });
+  });
+}
+
+export default baseSuite;

--- a/cloud/logger-debug/test/mocha.opts
+++ b/cloud/logger-debug/test/mocha.opts
@@ -1,0 +1,3 @@
+--compilers ts:ts-node/register
+--require source-map-support/register
+test/**.ts

--- a/cloud/logger-debug/tsconfig.json
+++ b/cloud/logger-debug/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "noImplicitAny": true,
+        "experimentalDecorators": true,
+        "strictNullChecks": true,
+        "sourceMap": true
+    },
+    "include": [
+        "src/",
+        "test/"
+    ]
+}


### PR DESCRIPTION
## Motivation

Create typescript interface for logger utility
JIRA [RAINCATCH-956](https://issues.jboss.org/browse/RAINCATCH-956)

## Progress

- [ ] Interface
- [ ] Unit tests
- [ ] Sample Implementation
- [ ] Functional tests
- [ ] Documentation
- [ ] Publishing


temp:
logged out like this:
```bash
 ✘  ~/raincatcher/raincatcher-core/cloud/logger-debug   RAINCATCH-956_logger_interface ●✚  mocha


  RaincatcherBase
    #customFunction
  NoopRaincatcherBase:debug: asdasd +0ms
      ✓ should add the supplied prefix
    Base
      #foo()
  base siute:error: hello +2ms
        ✓ should receive a string param


  2 passing (10ms)
```