### PR TITLE
RAINCATCH-923 - DataStore helpers

### DIFF
--- a/cloud/datastore/.gitignore
+++ b/cloud/datastore/.gitignore
@@ -1,0 +1,5 @@
+# generated code
+src/**/*.js
+src/**/*.map
+test/**/*.js
+test/**/*.map

--- a/cloud/datastore/README.md
+++ b/cloud/datastore/README.md
@@ -1,0 +1,1 @@
+# RainCatcher DataStore module

--- a/cloud/datastore/package.json
+++ b/cloud/datastore/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@raincatcher/data-store",
+  "version": "1.0.0",
+  "description": "Definies abstraction for storage",
+  "types": "src/index.ts",
+  "author": "feedhenry-raincatcher@redhat.com",
+  "license": "Apache-2.0",
+  "main": "src/",
+  "scripts": {
+    "clean": "del src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
+    "build": "tsc",
+    "start": "ts-node src/index.ts",
+    "test": "npm run clean && nyc mocha"
+  },
+  "nyc": {
+    "include": [
+      "src/**/*.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "check-coverage": true,
+    "lines": 75,
+    "functions": 100,
+    "branches": 80
+  },
+  "devDependencies": {
+    "@types/proxyquire": "^1.3.27",
+    "@types/mocha": "^2.2.41",
+    "proxyquire": "^1.8.0",
+    "del-cli": "^1.0.0",
+    "mocha": "^3.4.2",
+    "nyc": "^11.0.1",
+    "source-map-support": "^0.4.15",
+    "ts-node": "^3.0.4",
+    "typescript": "^2.3.4"
+  },
+  "dependencies": {
+    "mongodb": "^2.2.29"
+  }
+}

--- a/cloud/datastore/src/Repository.ts
+++ b/cloud/datastore/src/Repository.ts
@@ -1,0 +1,9 @@
+/**
+ * Marker interface for all classes that implements repository pattern
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface DataRepository {
+
+}
+
+export default DataRepository;

--- a/cloud/datastore/src/pagination/PageRequest.ts
+++ b/cloud/datastore/src/pagination/PageRequest.ts
@@ -1,0 +1,12 @@
+/**
+ *  Represents page request
+ *
+ *  @field page - zero-based page index.
+ *  @field size - the size of the page to be returned.
+ * Based on http://docs.spring.io/spring-data/data-commons/docs/current/api/org/springframework/data/domain/Pageable.html
+ */
+export interface PaggedRequest {
+  // Requested page
+  page: number;
+  size: number;
+}

--- a/cloud/datastore/src/pagination/PaggedResult.ts
+++ b/cloud/datastore/src/pagination/PaggedResult.ts
@@ -1,0 +1,8 @@
+/**
+ * Represents pagged result
+ */
+export interface PaggedResult<T>{
+  totalPages: number;
+  totalItems: number;
+  data: T[];
+}

--- a/cloud/datastore/src/providers/MongoRepository.ts
+++ b/cloud/datastore/src/providers/MongoRepository.ts
@@ -1,0 +1,17 @@
+var MongoClient = require('mongodb').MongoClient
+  , assert = require('assert');
+
+// Idea
+// We can have wfm-mongo module that will implement all repositories and will include some interfaces from here.
+// Providers should retrieve connection from top level application.
+
+export class MongoProvider {
+  constructor(url:string){
+    var url = 'mongodb://localhost:27017/myproject';
+    MongoClient.connect(url, function(err, db) {
+      assert.equal(null, err);
+    });
+  }
+
+}
+

--- a/cloud/datastore/src/sorting/Sort.ts
+++ b/cloud/datastore/src/sorting/Sort.ts
@@ -1,0 +1,19 @@
+/**
+ * Sorting directions
+ */
+export enum DIRECTION {
+  ASC,
+  DESC
+}
+
+
+/**
+ * Interface used to monitor sorting requirements
+ */
+export interface SortOrder {
+  // List of fields to sort results
+  sortData: string[]
+  // Sort direction
+  direction: DIRECTION
+
+}

--- a/cloud/datastore/tsconfig.json
+++ b/cloud/datastore/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es5",
+        "noImplicitAny": true,
+        "experimentalDecorators": true,
+        "strictNullChecks": true,
+        "sourceMap": true
+    },
+    "include": [
+        "src/",
+        "test/"
+    ]
+}


### PR DESCRIPTION
## Motivation

WIP Provide place for experiments on datastore.

## Supported objects

- [x] Paging (will be reused in WebAPI)
- [x] Sorting
- [ ] Query logic

## Idea

I think that we can have wfm-mongo, sec-mongo module that will implement all repositories and will include some interfaces from here. This one will include common elements.  This may sound messy but I couldn't really get anything reasonable that will be not limited. Providers should retrieve connection from top level application.

After building extensible support for queries I realized that we do not need that as users will just pass actual values to the repository methods and methods descriptions will need to explain clearly what we should query. For example:

```typescript
listUsersByNameAndManagerId(page:PageRequest, name:string, managerId:string) => PageResult<User>
```

Method name needs point to query specifics. For example:
```typescript
listUsersByNameOrManagerId(page:PageRequest,sort:SortOrder, name:string, managerId:string) => PageResult<User>
```
alternative:

``` typescript
interface Query {
  page : PageRequest, 
  name : string, 
  managerId : string
}
listUsersByNameAndManagerId(data: Query) => PageResult<User>
```

This is heavily inspired by SpringData ORM.

This can possibly make our methods name little bit long, but this will provide a lot of flexibility and will not require us to build any extensive data storage solution.

With this we really will need to have a lots of documentation for this process and team awareness.

Link entire team for comments: @feedhenry-raincatcher/rcdev 
