### PR TITLE
Fix sync client outdated ts options file

### DIFF
--- a/client/datasync-client/tsconfig.json
+++ b/client/datasync-client/tsconfig.json
@@ -1,15 +1,14 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
-        "noImplicitAny": true,
-        "experimentalDecorators": true,
-        "strictNullChecks": true,
-        "sourceMap": true,
-        "outDir": "dist"
-    },
-    "include": [
-        "src/",
-        "test/"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "noImplicitAny": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "sourceMap": true
+  },
+  "include": [
+    "src/",
+    "test/"
+  ]
 }


### PR DESCRIPTION
## Motivation

Sync client was compiling source code to dist folder, which was not standard behavior for clients.
This change fixes configuration to standard behaviour
