### PR TITLE
[Idea] Global logger example

### DIFF
--- a/cloud/logger/src/index.ts
+++ b/cloud/logger/src/index.ts
@@ -4,3 +4,23 @@ import {ConsoleLogger} from './ConsoleLogger';
 export {Logger} from  './Logger';
 export {BunyanLogger} from  './BunyanLogger';
 export {ConsoleLogger} from './ConsoleLogger';
+
+
+import {Logger} from  './Logger';
+
+// Global logger that will be used in all applications
+export let logger: Logger; 
+
+/**
+* Set default logger to be used by all modules
+*/
+export function setGlobalLogger(defaultLogger: Logger){
+   logger = defaultLogger;
+}
+
+/**
+* Retrieve default logger
+*/
+export function getGlobalLogger(location?:string): Logger{
+   return logger;
+}


### PR DESCRIPTION
## Motivation

Showcase for team how we can mount logger to be available globally.

I just noticed that we instantiate logger for each class and that's not effective and produces a lots of boilerplate. Passing logger or having wrapper common.js module with single instance maybe the answer but this code will need to be duplicated across the all the modules. 

Proposed solution is simple and will do the job.

## Note

Code is not ready to be merged. Presenting this as idea that needs to be improved etc.


## Usage
```
import {logger} from '@raincatcher/austin's-cloud-logger' 
logger.info("Going to have break now");
```
💯 **Super ping**   @austincunningham 
🔬  **Micro ping** @witmicko 



