### PR TITLE
RAINCATCH-1061 TaskRegistry

### DIFF
--- a/client/wfm/src/index.ts
+++ b/client/wfm/src/index.ts
@@ -1,22 +1,22 @@
 // Interfaces
-export {Executor} from './executor/Executor';
-export {ProcessInstance} from './process-instance/ProcessInstance';
-export {Process} from './process/Process';
-export {Result} from './result/Result';
-export {Task, TaskStatus, TaskEventData} from './task/Task';
-export {TaskHandler} from './task/TaskHandler';
+export { Executor } from './executor/Executor';
+export { ProcessInstance } from './process-instance/ProcessInstance';
+export { Process } from './process/Process';
+export { Result } from './result/Result';
+export { Task , TaskStatus, TaskEventData} from './task/Task';
+export { TaskHandler } from './task/TaskHandler';
 
 // Implementations
-export {ExecutorImpl} from './executor/ExecutorImpl';
-export {ProcessInstanceImpl} from './process-instance/ProcessInstanceImpl';
-export {ProcessImpl} from './process/ProcessImpl';
-export {BooleanResult} from './result/BooleanResult';
-export {UrlResult} from './result/UrlResult';
-export {BaseTask} from './task/BaseTask';
-export {TaskRegistry} from './task/TaskRegistry';
+export { ExecutorImpl } from './executor/ExecutorImpl';
+export { ProcessInstanceImpl } from './process-instance/ProcessInstanceImpl';
+export { ProcessImpl } from './process/ProcessImpl';
+export { BooleanResult } from './result/BooleanResult';
+export { UrlResult } from './result/UrlResult';
+export { BaseTask } from './task/BaseTask';
+export { TaskRegistry } from './task/TaskRegistry';
 
 // Repositories
-export {ExecutorRepository} from './executor/ExecutorRepository';
-export {ProcessRepository} from './process/ProcessRepository';
-export {ProcessInstanceRepository} from './process-instance/ProcessInstanceRepository';
-export {TaskRepository} from './task/TaskRepository';
+export { ExecutorRepository } from './executor/ExecutorRepository';
+export { ProcessRepository } from './process/ProcessRepository';
+export { ProcessInstanceRepository } from './process-instance/ProcessInstanceRepository';
+export { TaskRepository } from './task/TaskRepository';

--- a/client/wfm/src/index.ts
+++ b/client/wfm/src/index.ts
@@ -4,6 +4,7 @@ export {ProcessInstance} from './process-instance/ProcessInstance';
 export {Process} from './process/Process';
 export {Result} from './result/Result';
 export {Task, TaskStatus, TaskEventData} from './task/Task';
+export {TaskHandler} from './task/TaskHandler';
 
 // Implementations
 export {ExecutorImpl} from './executor/ExecutorImpl';
@@ -12,6 +13,7 @@ export {ProcessImpl} from './process/ProcessImpl';
 export {BooleanResult} from './result/BooleanResult';
 export {UrlResult} from './result/UrlResult';
 export {BaseTask} from './task/BaseTask';
+export {TaskRegistry} from './task/TaskRegistry';
 
 // Repositories
 export {ExecutorRepository} from './executor/ExecutorRepository';

--- a/client/wfm/src/task/TaskHandler.ts
+++ b/client/wfm/src/task/TaskHandler.ts
@@ -1,0 +1,10 @@
+import { ProcessInstance } from '../process-instance/ProcessInstance';
+import { Result } from '../result/Result';
+import { Task } from './Task';
+export interface TaskHandler {
+  id: string;
+  displayName: string;
+  execute(task: Task, processInstance: ProcessInstance): void;
+  finish(task: Task, processInstance: ProcessInstance): Result;
+  previous(task: Task, processInstance: ProcessInstance): Result;
+}

--- a/client/wfm/src/task/TaskHandler.ts
+++ b/client/wfm/src/task/TaskHandler.ts
@@ -17,3 +17,28 @@ export interface TaskHandler {
    */
   previous(task: Task, processInstance: ProcessInstance): Result;
 }
+
+import { BooleanResult } from '../result/BooleanResult';
+/**
+ * Throwaway draft of a custom TaskHandler
+ */
+class VehicleInspectionTaskHandler implements TaskHandler {
+  public id: 'vehicle-inspection';
+  public displayName: 'Vehicle Inspection';
+  public portalDirective = 'vehicleInspection';
+  public mobileDirective = 'vehicleInspectionForm';
+  public execute(task: Task, processInstance: ProcessInstance): void {
+    // render mobileDirective to proper container
+  }
+  public next(task: Task, processInstance: ProcessInstance): Result {
+    // should get called from angular controller,
+    // controller.next = () => {registry.get('vehicle-inspection').next(...);}
+    // TODO: update results to match needs of current UI
+    return new BooleanResult(true);
+  }
+  public previous(task: Task, processInstance: ProcessInstance): Result {
+    // should get called from angular controller,
+    // controller.back = () => {registry.get('vehicle-inspection').previous(...);}
+    return new BooleanResult(true);
+  }
+}

--- a/client/wfm/src/task/TaskHandler.ts
+++ b/client/wfm/src/task/TaskHandler.ts
@@ -4,7 +4,16 @@ import { Task } from './Task';
 export interface TaskHandler {
   id: string;
   displayName: string;
+  /**
+   * Starts the execution of a Task
+   */
   execute(task: Task, processInstance: ProcessInstance): void;
-  finish(task: Task, processInstance: ProcessInstance): Result;
+  /**
+   * Should be called when a Task is done
+   */
+  next(task: Task, processInstance: ProcessInstance): Result;
+  /**
+   * Should be called upon a user request to move to the previous Task
+   */
   previous(task: Task, processInstance: ProcessInstance): Result;
 }

--- a/client/wfm/src/task/TaskRegistry.ts
+++ b/client/wfm/src/task/TaskRegistry.ts
@@ -1,0 +1,42 @@
+import * as _ from 'lodash';
+import { TaskHandler } from './TaskHandler';
+
+/**
+ * Registry for containing the set of handlers for custom Task implementations
+ */
+export class TaskRegistry {
+  /**
+   * In-memory dictionary that maps string ids to the TaskHandler implementations
+   */
+  protected storage: {[id: string]: TaskHandler} = {};
+
+  /**
+   * Adds one or many handlers to the TaskRegistry
+   * @param handler The TaskHandlers to add
+   */
+  public register(handler: TaskHandler | TaskHandler[]): void {
+    if (Array.isArray(handler)) {
+      handler.forEach((h: TaskHandler) => this.storage[h.id] = h);
+    } else {
+      this.storage[handler.id] = handler;
+    }
+  }
+
+  /**
+   * Obtain a single TaskHandler by its unique id
+   * @param id Unique identification for the TaskHandler
+   */
+  public get(id: string): TaskHandler {
+    return this.storage[id];
+  }
+
+  /**
+   * Lists available ids for TaskHandlers
+   */
+  public listAvailable(): string[] {
+    return _.keys(this.storage);
+  }
+  public list(): TaskHandler[] {
+    return _.values(this.storage);
+  }
+}


### PR DESCRIPTION
## Description
Add a registry for custom Task implementations, that can be listed by UI so the user can select between them to be included in a new ProcessInstance

## Progress
- [X] TaskRegistry
- [X] TaskHandler interface
- [ ] Update Result to match current UI usage
- [ ] Unit tests
- [ ] Documentation
