### PR TITLE
[Proposition] Rename security interface

### DIFF
--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -13,7 +13,7 @@ import { defaultDeserializeUser, defaultSerializeUser } from './UserSerializer';
  * Security interface for Raincatcher authentication middleware
  * Contains all methods that should be used to protect express routes.
  */
-export interface Auth {
+export interface EndpointSecurity {
 
   /**
    * Initializes an Express application to use passport and express-session


### PR DESCRIPTION
## Motivation

One element I missed in my previous PR was renaming top level interface. 
I think we should:

- define interface names more carefully
- avoid using implementation specifics for interfaces 
- avoid using shorthands for names (prop => Property, Auth => Authorization)

Note: This change is not ready to be merged. Just idea.
 
## Security interface

In this particular case Auth interface suggest that we may deal with Authentication or Authorization. Shorter name causing confusion etc. Our interface is doing both so best to find more top level name. My suggestion in changes.

## Community voting

Vote 👍  👎  
Comments for different name propositions.