### PR TITLE
Add access denied handler for Passport

### DIFF
--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -110,7 +110,7 @@ export class PassportAuth implements EndpointSecurity {
    * a resource. This method can be overridden to provide a custom access denied handler
    */
   public accessDenied(req: express.Request, res: express.Response) {
-    res.status(403).send('Access Denied');
+    res.status(403).send();
   }
 
   /**

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -86,7 +86,7 @@ export class PassportAuth implements EndpointSecurity {
       }
 
       const hasRole = role ? this.userService.hasResourceRole(req.user, role) : true;
-      return hasRole ? next() : res.status(403).send();
+      return hasRole ? next() : this.accessDenied(req, res);
     };
   }
 
@@ -103,6 +103,14 @@ export class PassportAuth implements EndpointSecurity {
       failureRedirect: errorRedirect,
       successReturnToOrRedirect: defaultRedirect
     });
+  }
+
+  /**
+   * Handler for access denied responses in the event that a user is not authorized to access
+   * a resource. This method can be overridden to provide a custom access denied handler
+   */
+  public accessDenied(req: express.Request, res: express.Response) {
+    res.status(403).send('Access Denied');
   }
 
   /**

--- a/demo/server/src/modules/passport-auth/index.ts
+++ b/demo/server/src/modules/passport-auth/index.ts
@@ -22,9 +22,6 @@ export function init(app: express.Express) {
   const userService: UserService = new SampleUserService();
   const authService: PassportAuth = new PassportAuth(userRepo, userService);
   authService.init(app, sessionOpts);
-  authService.accessDenied = function(req: express.Request, res: express.Response) {
-    res.redirect('/access-denied');
-  };
   createRoutes(app, authService);
   return authService;
 }

--- a/demo/server/src/modules/passport-auth/index.ts
+++ b/demo/server/src/modules/passport-auth/index.ts
@@ -22,6 +22,9 @@ export function init(app: express.Express) {
   const userService: UserService = new SampleUserService();
   const authService: PassportAuth = new PassportAuth(userRepo, userService);
   authService.init(app, sessionOpts);
+  authService.accessDenied = function(req: express.Request, res: express.Response) {
+    res.redirect('/access-denied');
+  };
   createRoutes(app, authService);
   return authService;
 }


### PR DESCRIPTION
## Motivation
Currently, passport auth sends a a status of 403 upon the event of an unauthorized request. We need to create an access denied handler and allow this to be customized in order to match with Keycloak. 

## Description
Added an access denied handler which mimics Keycloak's [accessDenied](https://github.com/keycloak/keycloak-nodejs-connect/blob/master/index.js#L233) handler.

## Progress
- [x] Add access denied handler in passport auth
- [ ] Customize this handler so that it redirects to the `/access-denied` route

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-934
Related PR - https://github.com/TommyJ1994/raincatcher-core/pull/2

@wtrocki 
@TommyJ1994 