### PR TITLE
Use development as default configuration

### DIFF
--- a/cloud/datasync/package.json
+++ b/cloud/datasync/package.json
@@ -47,6 +47,6 @@
     "body-parser": "1.17.2",
     "cors": "2.8.3",
     "express": "4.15.3",
-    "fh-sync": "https://github.com/feedhenry/fh-sync#definition-fix"
+    "fh-sync": "1.0.6"
   }
 }

--- a/demo/server/src/util/config.ts
+++ b/demo/server/src/util/config.ts
@@ -19,15 +19,14 @@ export interface Config<T> {
  * - config-prod.json
  */
 export default class EnvironmentConfig<T> implements Config<T> {
-  private devEnv: boolean;
   private rawConfig: T;
 
   constructor() {
-    this.devEnv = process.env.NODE_ENV === 'development';
-    if (this.devEnv) {
-      this.rawConfig = require('../../config-dev.json');
-    } else {
+    const prodEnv = process.env.NODE_ENV === 'production';
+    if (prodEnv) {
       this.rawConfig = require('../../config-prod.json');
+    } else {
+      this.rawConfig = require('../../config-dev.json');
     }
   }
 


### PR DESCRIPTION
## Motivation

Production configuration should be used only when NODE_ENV is set to production.
Otherwise we should use development.

ping @TommyJ1994 