### PR TITLE
[RAINCATCH-1028] Add profile and logout route for PassportJS

### DIFF
--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -80,9 +80,9 @@ export class PassportAuth implements EndpointSecurity {
       if (!req.isAuthenticated()) {
         if (req.session) {
           // Used for redirecting to after a successful login when option successReturnToOrRedirect is defined.
-          req.session.returnTo = req.originalUrl;
+          req.session.returnTo = req.headers.referer;
         }
-        return res.redirect(this.loginRoute);
+        return res.status(401).send();
       }
 
       const hasRole = role ? this.userService.hasResourceRole(req.user, role) : true;

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -80,7 +80,7 @@ export class PassportAuth implements EndpointSecurity {
       if (!req.isAuthenticated()) {
         if (req.session) {
           // Used for redirecting to after a successful login when option successReturnToOrRedirect is defined.
-          req.session.returnTo = req.headers.referer;
+          req.session.returnTo = this.setReturnToUrl(req);
         }
         return res.status(401).send();
       }
@@ -111,6 +111,16 @@ export class PassportAuth implements EndpointSecurity {
    */
   public accessDenied(req: express.Request, res: express.Response) {
     res.status(403).send();
+  }
+
+  /**
+   * Sets the url to return to after successful login.
+   * This method can be overridden to provide a custom URL to return to
+   *
+   * @param returnToUrl - location to redirect to after a successful login
+   */
+  protected setReturnToUrl(req: express.Request) {
+    return req.headers.referer || req.originalUrl;
   }
 
   /**

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -76,17 +76,18 @@ export class PassportAuth implements EndpointSecurity {
    * @param role - Role which the user needs in order to access this resource
    */
   public protect(role?: string) {
+    const self = this;
     return (req: express.Request, res: express.Response, next: express.NextFunction) => {
       if (!req.isAuthenticated()) {
         if (req.session) {
           // Used for redirecting to after a successful login when option successReturnToOrRedirect is defined.
-          req.session.returnTo = this.setReturnToUrl(req);
+          req.session.returnTo = self.setReturnToUrl(req);
         }
         return res.status(401).send();
       }
 
       const hasRole = role ? this.userService.hasResourceRole(req.user, role) : true;
-      return hasRole ? next() : this.accessDenied(req, res);
+      return hasRole ? next() : self.accessDenied(req, res);
     };
   }
 
@@ -109,7 +110,7 @@ export class PassportAuth implements EndpointSecurity {
    * Handler for access denied responses in the event that a user is not authorized to access
    * a resource. This method can be overridden to provide a custom access denied handler
    */
-  public accessDenied(req: express.Request, res: express.Response) {
+  protected accessDenied(req: express.Request, res: express.Response) {
     res.status(403).send();
   }
 

--- a/cloud/passportauth/test/PassportAuthTest.ts
+++ b/cloud/passportauth/test/PassportAuthTest.ts
@@ -97,32 +97,36 @@ describe('Test Passport Auth', function() {
     });
   });
 
-  it('should redirect to the login route if user was not authenticated', function() {
+  it('should send a status of 401 if the user was not authenticated', function() {
     mockReq = {
       isAuthenticated: sinon.stub().returns(false),
-      originalUrl: 'testUrlToReturnTo'
+      headers: {
+        referer: 'testUrlToReturnTo'
+      }
     };
     testSubject.protect()(mockReq as express.Request, mockRes as express.Response, mockNext);
 
     sinon.assert.notCalled(mockNext);
-    sinon.assert.calledOnce(mockRes.redirect);
+    sinon.assert.calledOnce(mockRes.status);
     sinon.assert.calledOnce(mockReq.isAuthenticated);
-    sinon.assert.calledWith(mockRes.redirect, loginRoute);
+    sinon.assert.calledWith(mockRes.status, 401);
   });
 
   it('should assign a url to return to in session if session was defined', function() {
     mockReq = {
       isAuthenticated: sinon.stub().returns(false),
       session: {},
-      originalUrl: 'testUrlToReturnTo'
+      headers: {
+        referer: 'testUrlToReturnTo'
+      }
     };
     testSubject.protect()(mockReq as express.Request, mockRes as express.Response, mockNext);
 
     sinon.assert.notCalled(mockNext);
-    sinon.assert.calledOnce(mockRes.redirect);
+    sinon.assert.calledOnce(mockRes.status);
     sinon.assert.calledOnce(mockReq.isAuthenticated);
-    sinon.assert.calledWith(mockRes.redirect, loginRoute);
-    sinon.match.has(mockReq.session.returnTo, mockReq.url);
+    sinon.assert.calledWith(mockRes.status, 401);
+    sinon.match.has(mockReq.session.returnTo, mockReq.headers.referer);
   });
 
   it('should call next if the user was authenticated and the route was not protected by a role', function() {

--- a/demo/server/src/app.ts
+++ b/demo/server/src/app.ts
@@ -14,6 +14,16 @@ import appConfig from './util/config';
 
 const app: express.Express = express();
 const config = appConfig.getConfig();
+let corsConfig = {};
+if (!config.keycloakConfig) {
+  const dynamicOrigin = function(origin, callback) {
+    callback(null, true);
+  };
+  corsConfig = {
+    origin: dynamicOrigin,
+    credentials: true
+  };
+}
 
 if (config.morganOptions) {
   app.use(logger(config.morganOptions));
@@ -23,7 +33,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../public')));
 app.use(favicon(path.join(__dirname, '../public', 'favicon.ico')));
-app.use(cors());
+app.use(cors(corsConfig));
 
 app.engine('hbs', expressHbs());
 app.set('view engine', 'hbs');

--- a/demo/server/src/app.ts
+++ b/demo/server/src/app.ts
@@ -14,15 +14,26 @@ import appConfig from './util/config';
 
 const app: express.Express = express();
 const config = appConfig.getConfig();
-let corsConfig = {};
-if (!config.keycloakConfig) {
-  const dynamicOrigin = function(origin, callback) {
-    callback(null, true);
-  };
-  corsConfig = {
-    origin: dynamicOrigin,
-    credentials: true
-  };
+
+/**
+ * Function for setting CORS configuration. When using Passport as an auth service,
+ * the credentials must be set to true.By doing this, the origin cannot be set to
+ * '*'. Origin needs to be set to allow all origins for enabling cross-domain requests.
+ *
+ * @returns CORS configuration
+ */
+function getCorsConfig() {
+  let corsConfig = {};
+  if (!config.keycloakConfig) {
+    const dynamicOrigin = function(origin, callback) {
+      callback(null, true);
+    };
+    corsConfig = {
+      origin: dynamicOrigin,
+      credentials: true
+    };
+  }
+  return corsConfig;
 }
 
 if (config.morganOptions) {
@@ -33,7 +44,7 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../public')));
 app.use(favicon(path.join(__dirname, '../public', 'favicon.ico')));
-app.use(cors(corsConfig));
+app.use(cors(getCorsConfig()));
 
 app.engine('hbs', expressHbs());
 app.set('view engine', 'hbs');

--- a/demo/server/src/modules/passport-auth/index.ts
+++ b/demo/server/src/modules/passport-auth/index.ts
@@ -15,18 +15,31 @@ export function init(app: express.Express) {
   return authService;
 }
 
-function createRoutes(router: express.Express, auth: PassportAuth) {
+function createRoutes(router: express.Express, authService: PassportAuth) {
   router.get('/login', (req: express.Request, res: express.Response) => {
-    res.render('login', {
+    if (req.session) {
+      req.session.returnTo = req.headers.referer;
+    }
+    return res.render('login', {
       title: 'Feedhenry Workforce Management'
     });
   });
 
-  router.post('/login', auth.authenticate('/', '/loginError'));
+  router.post('/login', authService.authenticate('/', '/loginError'));
 
   router.get('/loginError', (req: express.Request, res: express.Response) => {
       return res.render('login', {
         title: 'Feedhenry Workforce Management',
         message: 'Invalid credentials'});
+  });
+
+  router.get('/profile', authService.protect(), (req: express.Request, res: express.Response) => {
+    res.json(req.user);
+  });
+
+  router.get('/logout', (req: express.Request, res: express.Response) => {
+    req.session.destroy(function(err) {
+      res.status(200).send();
+    });
   });
 }


### PR DESCRIPTION
## Motivation
The demo mobile/portal will require a `/profile` route to get user profile and a `/logout` route to log out the user. `Access-Control-Allow-Credentials` also needs to be set in the response to allow cookies to be passed in with the request for authentication. 

CORS does not allow a redirect with preflights therefore the protect() functionality of PassportJS should return a status of 401 instead.

## Description
- Add `/profile` and `/logout` route for PassportJS. 
- Set `Access-Control-Allow-Credentials` to be true for CORS requests.
- Updated Passport's protect() to send a status of 401 when the user is not authenticated


## Progress
- [x] Add `/profile` route
- [x] Add `/logout` route
- [x] Set `Access-Control-Allow-Credentials` to be true for CORS requests
- [x] Send `401` instead of a redirect on Passport's protect()
- [x] Update unit tests

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1028
Related PR - https://github.com/feedhenry-raincatcher/raincatcher-angularjs/pull/20
