### PR TITLE
Remove Keycloak Details from Demo Cloud Dev Config

### DIFF
--- a/demo/server/config-dev.json
+++ b/demo/server/config-dev.json
@@ -5,13 +5,6 @@
     "customDataHandlers": true,
     "seedDemoData": true
   },
-  "keycloakConfig": {
-    "realm": "raincatcher",
-    "auth-server-url": "http://localhost:8080/auth",
-    "ssl-required": "external",
-    "resource": "raincatcher-cloud",
-    "public-client": true
-  },
   "bunyanConfig": {
     "name": "Demo application",
     "level": "debug"


### PR DESCRIPTION
## Motivation
Remove Keycloak configuration from the Demo Cloud App development config file. Passport will be used by default, so the keycloak config is not necessary in the demo apps by default.

## Progress
- [x] Remove Keycloak Config

