### PR TITLE
Raincatch 1106 coveralls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ pids
 lib-cov
 
 # Coverage directory used by tools like istanbul
-coverage
+coverage_report/
 
 .idea
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 script:
 - npm run bootstrap
 - npm run lint
-- npm test
+- npm run test-ci
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # RainCatcher
+
+[![Build Status](https://travis-ci.org/feedhenry-raincatcher/raincatcher-core.svg?branch=master)](https://travis-ci.org/feedhenry-raincatcher/raincatcher-core) [![Coverage Status](https://coveralls.io/repos/github/feedhenry-raincatcher/raincatcher-core/badge.svg?branch=master)](https://coveralls.io/github/feedhenry-raincatcher/raincatcher-core?branch=master)
+
 Feedhenry RainCatcher Core Repository
 
 ## About RainCatcher

--- a/client/datasync-client/package.json
+++ b/client/datasync-client/package.json
@@ -22,6 +22,11 @@
     "require": [
       "ts-node/register"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "../../coverage_report/client-datasync-client",
     "check-coverage": true,
     "lines": 75,
     "functions": 60,

--- a/client/wfm/package.json
+++ b/client/wfm/package.json
@@ -25,6 +25,11 @@
       "ts-node/register",
       "source-map-support/register"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "../../coverage_report/client-wfm",
     "produce-source-map": true,
     "check-coverage": false,
     "lines": 75,

--- a/cloud/datasync/package.json
+++ b/cloud/datasync/package.json
@@ -21,6 +21,11 @@
     "require": [
       "ts-node/register"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "../../coverage_report/cloud-datasync",
     "check-coverage": true,
     "lines": 75,
     "functions": 80,

--- a/cloud/logger/package.json
+++ b/cloud/logger/package.json
@@ -23,6 +23,11 @@
     "require": [
       "ts-node/register"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "../../coverage_report/client-cloud-logger",
     "check-coverage": true,
     "lines": 75,
     "functions": 100,

--- a/cloud/passportauth/package.json
+++ b/cloud/passportauth/package.json
@@ -23,6 +23,11 @@
     "require": [
       "ts-node/register"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "../../coverage_report/cloud-passportauth",
     "check-coverage": true,
     "lines": 75,
     "functions": 100,

--- a/demo/server/.gitignore
+++ b/demo/server/.gitignore
@@ -3,3 +3,4 @@ src/**/*.js
 src/**/*.map
 test/**/*.js
 test/**/*.map
+coverage_report/

--- a/demo/server/package.json
+++ b/demo/server/package.json
@@ -7,7 +7,7 @@
   "author": "feedhenry-raincatcher@redhat.com",
   "license": "Apache-2.0",
   "scripts": {
-    "clean": "del src/*.js src/**/*.js src/*.map src/**/*.map test/**/*.js test/**/*.map",
+    "clean": "del coverage_report src/*.js src/**/*.js src/*.map src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
     "start": "ts-node src/index.ts",
     "test": "nyc mocha"
@@ -22,6 +22,11 @@
     "require": [
       "ts-node/register"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "coverage_report",
     "check-coverage": true,
     "lines": 75,
     "functions": 60,

--- a/package.json
+++ b/package.json
@@ -5,13 +5,19 @@
   "main": "index.js",
   "scripts": {
     "test": "lerna run test",
+    "test-ci": "npm-run-all test coverage:*",
+    "coverage:create-file": "echo '' > ./coverage_report/coverage_merged.info",
+    "coverage:merge-reports": "lcov-result-merger './coverage_report/*/lcov.info' './coverage_report/coverage_merged.info'",
+    "coverage:upload-coveralls": "cat ./coverage_report/coverage_merged.info | coveralls",
     "cleanInstall": "lerna exec npm install --ignore-scripts",
     "bootstrap": "lerna bootstrap",
     "start": "lerna run start  --parallel --stream --scope=@raincatcher/demo-*",
     "docs": "lerna exec -- typedoc --out docs/ --excludePrivate",
     "lint": "tslint '*/*/src/**/*.ts' '*/*/test/**/*.ts'",
     "build": "lerna run build",
-    "clean": "lerna run clean"
+    "clean": "npm-run-all clean:*",
+    "clean:coverage": "del coverage_report",
+    "clean:packages": "lerna run clean"
   },
   "repository": {
     "type": "git",
@@ -24,10 +30,13 @@
   },
   "homepage": "https://github.com/feedhenry-raincatcher/raincatcher#readme",
   "devDependencies": {
+    "coveralls": "^2.13.1",
+    "del-cli": "^1.0.0",
+    "lcov-result-merger": "^1.2.0",
     "lerna": "^2.0.0-rc.5",
+    "npm-run-all": "^4.0.2",
     "tslint": "^5.4.3",
     "typescript": "^2.3.4"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/templates/base/.gitignore
+++ b/templates/base/.gitignore
@@ -3,3 +3,4 @@ src/**/*.js
 src/**/*.map
 test/**/*.js
 test/**/*.map
+coverage_report/

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "main": "src/",
   "scripts": {
-    "clean": "del src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
+    "clean": "del coverage_report src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
     "start": "ts-node src/index.ts",
     "test": "npm run clean && nyc mocha"
@@ -22,6 +22,11 @@
     "require": [
       "ts-node/register"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "coverage_report",
     "check-coverage": true,
     "lines": 75,
     "functions": 100,
@@ -39,3 +44,4 @@
     "typescript": "^2.3.4"
   }
 }
+

--- a/templates/javascript-usage/.gitignore
+++ b/templates/javascript-usage/.gitignore
@@ -1,0 +1,1 @@
+coverage_report/

--- a/templates/javascript-usage/package.json
+++ b/templates/javascript-usage/package.json
@@ -6,6 +6,7 @@
   "author": "feedhenry-raincatcher@redhat.com",
   "license": "Apache-2.0",
   "scripts": {
+    "clean": "del coverage_report",
     "test": "nyc mocha",
     "debug": "node --inspect-brk node_modules/.bin/_mocha",
     "debug-legacy": "mocha --debug-brk"
@@ -14,6 +15,11 @@
     "include": [
       "lib/**/*.js"
     ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "report-dir": "coverage_report",
     "check-coverage": true,
     "lines": 75,
     "functions": 100,
@@ -23,6 +29,7 @@
     "@raincatcher/example-base": "1.0.0"
   },
   "devDependencies": {
+    "del-cli": "^1.0.0",
     "mocha": "^3.4.2",
     "source-map-support": "^0.4.15",
     "nyc": "^11.0.1"


### PR DESCRIPTION
## Motivation

This PR is used to implement coveralls integration with raincatcher-core to provide a tracking system of our code coverage over time. An new command `npm run test-ci` is provided for running tests on Travis that will automatically upload.

## Description

1. Edit multiple package.json files to produce coverage reports
2. Add lcov-result-merger to combine multiple reports - the lcov report contents will be uploaded by coveralls
3. Add coveralls integration to upload combined coverage report to coveralls
4. Edit .gitignore files to ignore coverage report folders
5. Add npm-run-all to main package.json to reduce the script length and provide script isolation. Composite scripts can be created and steps to tasks can be triggered easily
6. Edit .travis.yml file to run new test-ci rather than test, to allow test to be used for local development without trying to merge reports and upload to coveralls
7. Add removal of coverage_report folders to clean commands 
8. Add Build and Coverage badges from Travis and Coveralls to README.md 

## Progress
- [x] Edit package.json in multiple repos to provide support for lcov coverage output 
- [x] Added lcov-result-merger to combine multiple files
- [x] Added ability to upload to coveralls in package.json
- [x] Edited .gitignore files to ignore coverage report folders
- [x] Added npm-run-all as dev dependency and created some new scripts and composite scripts in main package.json
- [x] Edited .travis.yml
- [x] Updated clean commands where necessary 
- [x] Added badges to README.md
- [ ] Documentation

## Additional Notes

