### PR TITLE
[RAINCATCH-1164] fix redirect bug after login when already authenticated

### DIFF
--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -82,6 +82,7 @@ export class PassportAuth implements EndpointSecurity {
         if (req.session) {
           // Used for redirecting to after a successful login when option successReturnToOrRedirect is defined.
           req.session.returnTo = self.setReturnToUrl(req);
+          req.session.clientURL = req.session.returnTo;
         }
         return res.status(401).send();
       }
@@ -104,6 +105,21 @@ export class PassportAuth implements EndpointSecurity {
       failureRedirect: errorRedirect,
       successReturnToOrRedirect: defaultRedirect
     });
+  }
+
+  /**
+   * A middleware which checks if the user is authenticated.
+   * If the user is already authenticated, the user is redirected back to the application,
+   * otherwise it will proceed onto authenticating the user.
+   */
+  public isAuthenticated() {
+    return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+      if (req.isAuthenticated() && req.session) {
+        res.redirect(req.session.clientURL);
+      } else {
+        next();
+      }
+    };
   }
 
   /**

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -127,11 +127,13 @@ export class PassportAuth implements EndpointSecurity {
   /**
    * Sets the url to return to after successful login.
    * This method can be overridden to provide a custom URL to return to
-   *
-   * @param returnToUrl - location to redirect to after a successful login
    */
   protected setReturnToUrl(req: express.Request) {
-    return req.headers.referer || req.originalUrl;
+    if (req.headers && req.headers.referer) {
+      return req.headers.referer;
+    }
+
+    return req.originalUrl;
   }
 
   /**

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -93,31 +93,25 @@ export class PassportAuth implements EndpointSecurity {
   }
 
   /**
-   * Create middleware for authentication purposes
-   * This method wraps `passport.authenticate` to provide middleware for authenticating users.
+   * Creates a middleware for authentication purposes.
+   * This method wraps `passport.authenticate` to provide a middleware for authenticating users.
+   * It also includes a check if the user is already authenticated. If the user is already
+   * authenticated, it redirects back to the application, otherwise, it proceeds to authenticate
+   * the user.
    *
    * @param defaultRedirect - location to redirect after successful authentication
    *                          when login page was loaded directly (without redirect)
    * @param errorRedirect - location to redirect after unsuccessful authentication
    */
   public authenticate(defaultRedirect: string, errorRedirect?: string) {
-    return passport.authenticate('local', {
-      failureRedirect: errorRedirect,
-      successReturnToOrRedirect: defaultRedirect
-    });
-  }
-
-  /**
-   * A middleware which checks if the user is authenticated.
-   * If the user is already authenticated, the user is redirected back to the application,
-   * otherwise it will proceed onto authenticating the user.
-   */
-  public isAuthenticated() {
     return (req: express.Request, res: express.Response, next: express.NextFunction) => {
       if (req.isAuthenticated() && req.session) {
-        res.redirect(req.session.clientURL);
+        return res.redirect(req.session.clientURL);
       } else {
-        next();
+        return passport.authenticate('local', {
+          failureRedirect: errorRedirect,
+          successReturnToOrRedirect: defaultRedirect
+        })(req, res, next);
       }
     };
   }

--- a/cloud/passportauth/test/PassportAuthTest.ts
+++ b/cloud/passportauth/test/PassportAuthTest.ts
@@ -44,6 +44,7 @@ describe('Test Passport Auth', function() {
         password: 'testError'
       },
       logIn: sinon.spy(),
+      isAuthenticated: sinon.stub().returns(false),
       user: null
     };
 
@@ -64,6 +65,7 @@ describe('Test Passport Auth', function() {
         password: 'invalidPassword'
       },
       logIn: sinon.spy(),
+      isAuthenticated: sinon.stub().returns(false),
       user: null
     };
 
@@ -84,6 +86,7 @@ describe('Test Passport Auth', function() {
         password: 'testPassword'
       },
       logIn: sinon.spy(),
+      isAuthenticated: sinon.stub().returns(false),
       user: null
     };
 
@@ -172,6 +175,5 @@ describe('Test Passport Auth', function() {
 
       done();
     });
-
   });
 });

--- a/demo/server/src/modules/passport-auth/index.ts
+++ b/demo/server/src/modules/passport-auth/index.ts
@@ -26,7 +26,7 @@ function createRoutes(router: express.Express, authService: PassportAuth) {
     });
   });
 
-  router.post('/login', authService.isAuthenticated(), authService.authenticate('/', '/loginError'));
+  router.post('/login', authService.authenticate('/', '/loginError'));
 
   router.get('/loginError', (req: express.Request, res: express.Response) => {
     return res.render('login', {

--- a/demo/server/src/modules/passport-auth/index.ts
+++ b/demo/server/src/modules/passport-auth/index.ts
@@ -26,12 +26,12 @@ function createRoutes(router: express.Express, authService: PassportAuth) {
     });
   });
 
-  router.post('/login', authService.authenticate('/', '/loginError'));
+  router.post('/login', authService.isAuthenticated(), authService.authenticate('/', '/loginError'));
 
   router.get('/loginError', (req: express.Request, res: express.Response) => {
-      return res.render('login', {
-        title: 'Feedhenry Workforce Management',
-        message: 'Invalid credentials'});
+    return res.render('login', {
+      title: 'Feedhenry Workforce Management',
+      message: 'Invalid credentials'});
   });
 
   router.get('/profile', authService.protect(), (req: express.Request, res: express.Response) => {


### PR DESCRIPTION
## Motivation
When logging into a demo app when you're already logged into another, it will redirect you to http://localhost:8001/ which will render `{ name: "raincatcher", version: "1.0.0"}`. We need to check if the user is already authenticated before calling Passport's authenticate to redirect back to the application.

## Description
Once a user has already successfully logged in, Passport deletes *req.session.returnTo* field which causes Passport to redirect to the default URL which is currently '/'. Check if the user is already authenticated before calling Passport's authenticate function. 

## Progress
- [x] Add isAuthenticated middleware to Passport.
- [x] Add this middleware to the login route.
- [x] Unit tests

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1164
