### PR TITLE
remove checks for user properties to fix types error

### DIFF
--- a/demo/server/src/modules/wfm-user/StaticUsersRepository.ts
+++ b/demo/server/src/modules/wfm-user/StaticUsersRepository.ts
@@ -12,9 +12,7 @@ export const users: User[] = require('./users.json');
 export class StaticUsersRepository implements UsersRepository {
   public getUser(id: string | number): Bluebird<User> {
     const foundUser = _.find(users, function(user: User) {
-      if (user && user.name) {
-        return user.id === id;
-      }
+      return user.id === id;
     });
     if (!foundUser) {
       return Bluebird.reject(`User with id ${id} not found`);
@@ -27,9 +25,7 @@ export class StaticUsersRepository implements UsersRepository {
       filteredList = [];
     } else {
       filteredList = _.filter(users, function(user: User) {
-        if (user.name) {
-          return user.name.toLowerCase().indexOf(filter.toLowerCase()) !== -1;
-        }
+        return user.name.toLowerCase().indexOf(filter.toLowerCase()) !== -1;
       });
     }
     return Bluebird.resolve(_.take(filteredList, limit));


### PR DESCRIPTION
## Motivation
Demo server throws the following error when trying to run `npm run start`. 
`Argument of type '(user: User) => boolean | undefined' is not assignable to parameter of type 'string | [string, any] | Partial<User> | undefined'.`

## Description
Removed checks for user properties to fix this error. The user properties should be a given since it is required by the user type. 
