### PR TITLE
[RAINCATCH-1168] Add search handler for api

### DIFF
--- a/cloud/wfm-rest-api/README.md
+++ b/cloud/wfm-rest-api/README.md
@@ -109,6 +109,16 @@ Where `:objectId` is an `id` field of the object.
 
 Where `:objectId` is an `id` field of the object.
 
+### Search for objects
+
+Retrieves a list of objects that satisfies a query.
+
+> GET {object}/search
+
+A query can be made by providing a json `filter` query parameter
+
+For example `filter = {'title': 'Example'}`
+
 ### Error handling
 
 In case of error express `next` callback is being called with `ApiError` instance.

--- a/cloud/wfm-rest-api/README.md
+++ b/cloud/wfm-rest-api/README.md
@@ -111,7 +111,7 @@ Where `:objectId` is an `id` field of the object.
 
 ### Search for objects
 
-Retrieves a list of objects that satisfies a query.
+Retrieves a list of objects that matches a user query.
 
 > GET {object}/search
 

--- a/cloud/wfm-rest-api/src/impl/ApiController.ts
+++ b/cloud/wfm-rest-api/src/impl/ApiController.ts
@@ -129,7 +129,7 @@ export class ApiController<T> {
       if (parsedFilter) {
         const propertiesToFilter = new Array();
         for (const property in parsedFilter) {
-          if (property) {
+          if (property && parsedFilter[property] && parsedFilter[property].length !== 0) {
             const propertyToFilter = {
               [property]: {
                 $regex: '.*' + parsedFilter[property] + '.*',


### PR DESCRIPTION
## Description
Ensure that the filter section in portal don't just operate on local data.

## Progress
- [x] Create search handler
- [x] Add `/search` to routes
- [x] Unit tests
- [x] Documentation

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1168
