### PR TITLE
Update import of EndpointSecurity

### DIFF
--- a/demo/server/src/modules/index.ts
+++ b/demo/server/src/modules/index.ts
@@ -1,4 +1,4 @@
-import { EndpointSecurity } from '@raincatcher/auth-passport';
+import { EndpointSecurity } from '@raincatcher/express-auth';
 import { getLogger } from '@raincatcher/logger';
 import initData from '@raincatcher/wfm-demo-data';
 import { WfmRestApi } from '@raincatcher/wfm-rest-api';


### PR DESCRIPTION
## Description
Core fails to compile due to failed import on endpoint security. The endpoint security interface has been moved to express-auth. Update to import EndpointSecurity from express-auth rather than Auth-Passport. 
