### PR TITLE
[RAINCATCH-1182] Fix loglevel compile issue

### DIFF
--- a/common/logger/package.json
+++ b/common/logger/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@types/bunyan": "^1.8.2",
     "@types/chai": "^4.0.3",
-    "@types/loglevel": "^1.4.29",
     "@types/mocha": "^2.2.41",
     "@types/proxyquire": "^1.3.27",
     "chai": "^4.1.1",

--- a/common/logger/src/ClientLogger.ts
+++ b/common/logger/src/ClientLogger.ts
@@ -1,5 +1,17 @@
-import * as logger from 'loglevel';
 import { Logger } from './Logger';
+// tslint:disable-next-line:no-var-requires
+const logger: any = require('loglevel');
+
+// imported from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/loglevel/index.d.ts#L9
+// see https://issues.jboss.org/browse/RAINCATCH-1183 and https://issues.jboss.org/browse/RAINCATCH-1182 for reasons
+export const enum LogLevel {
+  TRACE = 0,
+  DEBUG = 1,
+  INFO = 2,
+  WARN = 3,
+  ERROR = 4,
+  SILENT = 5
+}
 
 /**
  * Default client (browser) logger implementation using loglevel library

--- a/common/logger/src/index.ts
+++ b/common/logger/src/index.ts
@@ -4,7 +4,7 @@ import { EmptyLogger, Logger } from './Logger';
 
 export { Logger } from './Logger';
 export { BunyanLogger } from './BunyanLogger';
-export { ClientLogger } from './ClientLogger';
+export { ClientLogger, LogLevel } from './ClientLogger';
 
 let logger: Logger = new EmptyLogger();
 

--- a/common/logger/test/ClientLogger.ts
+++ b/common/logger/test/ClientLogger.ts
@@ -1,7 +1,7 @@
 /// <reference types="mocha" />
 'use strict';
 
-import { ClientLogger } from '../src/ClientLogger';
+import { ClientLogger, LogLevel } from '../src/ClientLogger';
 const loggerObject: object = { test: 'test' };
 const emptyObject: object = {};
 


### PR DESCRIPTION
## Motivation
Fix compilation issues from hybrid hoisting and non-hoisting bootstrapping via using the core and angularjs repos together.

## Description
Use the loglevel library untyped, copy over relevant enum.

This should fix the compilation issues without changing the logger's public library.
