### PR TITLE
RAINCATCH-1198 - sync mapper

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in the repo.
-*       @wtrocki @austincunningham @witmicko @paolobueno @JameelB

--- a/cloud/datasync/README.md
+++ b/cloud/datasync/README.md
@@ -50,7 +50,7 @@ const router = middleware.createSyncExpressRouter();
 app.use('/', router);
 ```
 
-See [integration](./integration) for complete runnable example.
+See [example app](https://github.com/feedhenry-raincatcher/raincatcher-core/tree/master/cloud/datasync/example) for complete runnable example.
 
 ## Accessing underlying sync library
 
@@ -65,9 +65,9 @@ sync.anyapicall(...) ;
 Where `anyapicall` is one of the types defined in:
 https://github.com/feedhenry/fh-sync/blob/master/types/fh-sync.d.ts
 
-For more advanced usages please follow [FeedHenry sync documentation](https://github.com/feedhenry/fh-sync/tree/master/docs)
+For more advanced usages please follow [FeedHenry sync documentation](https://access.redhat.com/documentation/en-us/red_hat_mobile_application_platform_hosted/3/html/client_api/fh-sync)
 
 ## Overriding sync filter on server
 
 By default sync clients can specify any type of filter and efectivelly get access to
-every record for dataset. If you wish to disable user query_filters for certain datasets for security reasons `SyncMapperMiddleware` should be used, before mounting sync express router.
+every record for dataset. If you wish to disable user query_filters for certain datasets for security reasons `userMapperMiddleware` should be used, before mounting sync express router.

--- a/cloud/datasync/README.md
+++ b/cloud/datasync/README.md
@@ -66,3 +66,8 @@ Where `anyapicall` is one of the types defined in:
 https://github.com/feedhenry/fh-sync/blob/master/types/fh-sync.d.ts
 
 For more advanced usages please follow [FeedHenry sync documentation](https://github.com/feedhenry/fh-sync/tree/master/docs)
+
+## Overriding sync filter on server
+
+By default sync clients can specify any type of filter and efectivelly get access to
+every record for dataset. If you wish to disable user query_filters for certain datasets for security reasons `SyncMapperMiddleware` should be used, before mounting sync express router.

--- a/cloud/datasync/src/index.ts
+++ b/cloud/datasync/src/index.ts
@@ -5,6 +5,7 @@ export * from './options/SyncGlobalOptions';
 export * from './options/SyncDatasetOptions';
 export * from './SyncApi';
 export * from './web/SyncWebExpress';
+export * from './web/SyncMapperMiddleware';
 
 export { sync };
 export { SyncServer };

--- a/cloud/datasync/src/web/SyncMapperMiddleware.ts
+++ b/cloud/datasync/src/web/SyncMapperMiddleware.ts
@@ -13,11 +13,15 @@ const logger = getLogger();
  *
  * @param dataset - id of dataset to filter
  * @param fieldName - name of field that should be substituted with user id
+ * @param explicit - reject other query parameters and filter only by user field
  */
-export function userMapperMiddleware(dataset: string, fieldName: string) {
+export function userMapperMiddleware(dataset: string, fieldName: string, explicit?: boolean) {
   const middleware = function(req: express.Request, res: express.Response, next) {
     if (req.user) {
       if (req.body.dataset_id === dataset && req.body.query_params) {
+        if (explicit) {
+          req.body.query_params = {};
+        }
         req.body.query_params[fieldName] = req.user.id;
       }
       next();

--- a/cloud/datasync/src/web/SyncMapperMiddleware.ts
+++ b/cloud/datasync/src/web/SyncMapperMiddleware.ts
@@ -1,0 +1,30 @@
+import { getLogger } from '@raincatcher/logger';
+import * as express from 'express';
+import * as sync from 'fh-sync';
+import * as path from 'path';
+const logger = getLogger();
+
+/**
+ * Create middleware for swapping user id with logged user.
+ * By using this middleware sync implementations can make sure that filter passed from user
+ * application wasn't modified to fetch another user data.
+ *
+ * Note: this middleware requires req.user.id to be present
+ *
+ * @param dataset - id of dataset to filter
+ * @param fieldName - name of field that should be substituted with user id
+ */
+export function userMapperMiddleware(dataset: string, fieldName: string) {
+  const middleware = function(req: express.Request, res: express.Response, next) {
+    if (req.user) {
+      if (req.body.dataset_id === dataset && req.body.query_params) {
+        req.body.query_params[fieldName] = req.user.id;
+      }
+      next();
+    } else {
+      getLogger().info('Sync request made without user session present');
+      next(new Error('Security error. User is not present'));
+    }
+  };
+  return middleware;
+}

--- a/cloud/datasync/test/SyncMapperMiddleware.ts
+++ b/cloud/datasync/test/SyncMapperMiddleware.ts
@@ -1,0 +1,51 @@
+import * as assert from 'assert';
+import { userMapperMiddleware } from '../src/index';
+
+describe('FeedHenry Sync Mapper Tests', function() {
+  const res: any = {};
+  const mapperField = 'field';
+  const userId = 'serv33gsd';
+  const datasetId = 'testDataset';
+  describe('Test end user api', function() {
+    it('create middleware with explicit flag', function(done) {
+      const middleware = userMapperMiddleware(datasetId, mapperField, true);
+      const req: any = {
+        user: { id: userId },
+        body: { dataset_id: datasetId, query_params: { otherField: 'value' } }
+      };
+      req.body.query_params[mapperField] = 7;
+      middleware(req, res, function(err) {
+        assert.ok(!err);
+        assert.equal(req.body.query_params[mapperField], userId);
+        assert.ok(!req.body.query_params.otherField);
+        done();
+      });
+    });
+    it('create middleware without explicit flag', function(done) {
+      const middleware = userMapperMiddleware(datasetId, mapperField, false);
+      const req: any = {
+        user: { id: userId },
+        body: { dataset_id: datasetId, query_params: { otherField: 'value' } }
+      };
+      req.body.query_params[mapperField] = 7;
+      middleware(req, res, function(err) {
+        assert.ok(!err);
+        assert.equal(req.body.query_params[mapperField], userId);
+        assert.ok(req.body.query_params.otherField);
+        done();
+      });
+    });
+    it('create middleware without user', function(done) {
+      const middleware = userMapperMiddleware(datasetId, mapperField, false);
+      const req: any = {
+        body: { dataset_id: datasetId, query_params: { otherField: 'value' } }
+      };
+      req.body.query_params[mapperField] = 7;
+      middleware(req, res, function(err) {
+        assert.ok(err);
+        assert.ok(req.body.query_params.otherField);
+        done();
+      });
+    });
+  });
+});

--- a/demo/server/src/modules/datasync/Router.ts
+++ b/demo/server/src/modules/datasync/Router.ts
@@ -1,5 +1,0 @@
-import SyncServer, { SyncApi, SyncExpressMiddleware, SyncOptions } from '@raincatcher/datasync-cloud';
-
-// Mount router at specific location
-const middleware: SyncExpressMiddleware = new SyncExpressMiddleware('');
-export const router = middleware.createSyncExpressRouter();

--- a/demo/server/src/modules/index.ts
+++ b/demo/server/src/modules/index.ts
@@ -62,7 +62,7 @@ function syncSetup(app: express.Express) {
   const syncRouter = middleware.createSyncExpressRouter();
 
   app.use('/sync', securityMiddleware.protect(role));
-  app.use('/sync', userMapperMiddleware('workorders', 'assignee'));
+  app.use('/sync', userMapperMiddleware('workorders', 'assignee', true));
   app.use('/sync', syncRouter);
 
   return syncConnector().then(function(connections: { mongo: Db, redis: any }) {


### PR DESCRIPTION
## Motivation

Allow to override query filter on server for security reasons. 
Typical usage for filter will be to list results per specific user and do not allow any other filters for security reasons. This fix adds flexible way to do it. 

## Progress
- [x] Enable sync security
- [x] Create mapper
- [x] Add explicit option
- [x] Unit tests
- [x] Documentation


