### PR TITLE
RAINCATCH-1143 - Externalize mongo options for performance tests

### DIFF
--- a/demo/server/README.md
+++ b/demo/server/README.md
@@ -20,8 +20,10 @@ When process start you can connect to it using ide of your choice.
 
 ## Prerequisites
 
-- mongodb installed and running on port 27017.
+- mongodb installed and running on port 27017
+URL controlled by `process.env.MONGO_CONNECTION_URL` and `config-{env}.json` file.
 - redis installed and running on port 6379
+URL controlled by `process.env.REDIS_CONNECTION_URL` and `config-{env}.json` file.
 
 ## Configuration
 

--- a/demo/server/config-dev.json
+++ b/demo/server/config-dev.json
@@ -12,5 +12,12 @@
   "bunyanConfig": {
     "name": "Demo application",
     "level": "debug"
+  },
+  "mongodb": {
+    "url": "mongodb://127.0.0.1:27017/raincatcher",
+    "options": {}
+  },
+  "redis": {
+    "url": "redis://127.0.0.1:6379"
   }
 }

--- a/demo/server/config-prod.json
+++ b/demo/server/config-prod.json
@@ -20,5 +20,12 @@
     "ssl-required": "",
     "resource": "",
     "use-resource-role-mappings": true
- }
+  },
+  "mongodb": {
+    "url": "mongodb://127.0.0.1:27017/raincatcher",
+    "options": {}
+  },
+  "redis": {
+    "url": "redis://127.0.0.1:6379"
+  }
 }

--- a/demo/server/src/modules/datasync/Connector.ts
+++ b/demo/server/src/modules/datasync/Connector.ts
@@ -13,9 +13,9 @@ process.env.DEBUG = 'fh-mbaas-api:sync';
 // Sync connection options
 const connectOptions: SyncOptions = {
   datasetConfiguration: {
-    mongoDbConnectionUrl: process.env.MONGO_CONNECTION_URL || 'mongodb://127.0.0.1:27017/raincatcher',
-    mongoDbOptions: {},
-    redisConnectionUrl: process.env.REDIS_CONNECTION_URL || 'redis://127.0.0.1:6379'
+    mongoDbConnectionUrl: process.env.MONGO_CONNECTION_URL || appConfig.getConfig().mongodb.url,
+    mongoDbOptions: appConfig.getConfig().mongodb.options,
+    redisConnectionUrl: process.env.REDIS_CONNECTION_URL || appConfig.getConfig().redis.url
   },
   globalSyncOptions: { useCache: false }
 };

--- a/demo/server/src/util/Config.ts
+++ b/demo/server/src/util/Config.ts
@@ -58,6 +58,13 @@ export interface CloudAppConfig {
   sync: {
     customDataHandlers: boolean;
   };
+  mongodb: {
+    url: string
+    options: any
+  };
+  redis: {
+    url: string
+  };
 }
 const appConfig: Config<CloudAppConfig> = new EnvironmentConfig<CloudAppConfig>();
 


### PR DESCRIPTION
## Motivation

Externalize mongo options for performance tests. 
Developers should have clear way do redefine mongodb connection options in configuration for production usage. 

