### PR TITLE
Update default target organization for templates

### DIFF
--- a/scripts/apps.json
+++ b/scripts/apps.json
@@ -1,14 +1,14 @@
 {
   "server": {
     "path": "demo/server",
-    "repo": "/wfm-server.git"
+    "repo": "/raincatcher-server.git"
   },
   "mobile": {
     "path": "demo/mobile",
-    "repo": "/wfm-mobile.git"
+    "repo": "/raincatcher-mobile.git"
   },
   "portal": {
     "path": "demo/portal",
-    "repo": "/wfm-portal.git"
+    "repo": "/raincatcher-portal.git"
   }
 }

--- a/scripts/publish-app.js
+++ b/scripts/publish-app.js
@@ -19,7 +19,7 @@ var args = require('yargs')
   .usage('Usage: $0 <app name>')
   .alias('o', 'org')
   .describe('org', 'github organization/user to target publication')
-  .default('org', 'feedhenry-templates')
+  .default('org', 'feedhenry-raincatcher')
   .argv;
 
 // get version from lerna global version


### PR DESCRIPTION
## Motivation
Change publication target from feedhenry-templates to the main feedhenry-raincatcher

## Description
Change default target github organization and repository names
