### PR TITLE
[RAINCATCH-1263] Move keycloak realm json file to core templates

### DIFF
--- a/demo/server/templates/README.md
+++ b/demo/server/templates/README.md
@@ -1,0 +1,2 @@
+# RainCatcher Keycloak Realm Template
+This template is made for RainCatcher demo purposes only. Please note that this is not suited to be used for production. 

--- a/demo/server/templates/raincatcher-realm.json
+++ b/demo/server/templates/raincatcher-realm.json
@@ -1,0 +1,324 @@
+{
+    "realm": "raincatcher",
+    "enabled": true,
+    "sslRequired": "external",
+    "registrationAllowed": true,
+    "requiredCredentials": [ "password" ],
+    "users" : [
+        {
+            "username" : "trever",
+            "enabled": true,
+            "email" : "trever@wfm.com",
+            "firstName": "Trever",
+            "lastName": "Smith",
+            "clientRoles": {
+                "account": ["view-profile", "manage-account"]
+            },
+            "groups" : [
+              "users"
+            ],
+            "attributes" : {
+            "id" : "rkX1fdSH",
+            "name" : "Trever Smith",
+            "position" : "Senior Truck Driver",
+            "phone" : "2657258272",
+            "notes" : "Trever doesn't work during the weekends.",
+            "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/kolage/128.jpg",
+            "banner" : "http://web18.streamhoster.com/pentonmedia/beefmagazine.com/TreverStockyards_38371.jpg"
+          },
+          "credentials" : [ {
+          "type" : "password",
+          "value" : "123"
+        } ]
+      },
+      {
+          "username" : "daisy",
+          "enabled": true,
+          "email" : "daisy@wfm.com",
+          "firstName": "Daisy",
+          "lastName": "Dialer",
+          "clientRoles": {
+              "account": ["view-profile", "manage-account"]
+          },
+          "groups" : [
+            "admins"
+          ],
+          "attributes" : {
+            "id" : "rJeXyfdrH",
+            "name" : "Daisy Dialer",
+            "position" : "Junior Dispatcher",
+            "phone" : "2657548176",
+            "notes" : "Daisy doesn't work during the weekends.",
+            "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/madysondesigns/128.jpg",
+            "banner" : "https://s3-eu-west-1.amazonaws.com/raincatcher-files/Screen+Shot+2017-03-27+at+11.04.27.png"
+        },
+        "credentials" : [ {
+        "type" : "password",
+        "value" : "123"
+      } ]
+    },
+    {
+        "username" : "max",
+        "enabled": true,
+        "email" : "max@wfm.com",
+        "firstName": "Max",
+        "lastName": "A. Million",
+        "credentials" : [ {
+              "type" : "password",
+              "value" : "123"
+        } ],
+        "clientRoles": {
+            "account": ["view-profile", "manage-account"]
+        },
+        "groups" : [
+          "admins"
+        ],
+        "attributes" : {
+          "id" : "H1ZmkzOrr",
+          "name" : "Max A. Million",
+          "position" : "Manager",
+          "phone" : "2657134154",
+          "notes" : "Max doesn't work during the weekends.",
+          "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/davidburlton/128.jpg",
+          "banner" : "https://s3-eu-west-1.amazonaws.com/raincatcher-files/Screen+Shot+2017-03-27+at+11.04.27.png"
+      }
+    },
+    {
+        "username" : "bill",
+        "enabled": true,
+        "email" : "billb@wfm.com",
+        "firstName": "Bill",
+        "lastName": "Baller",
+        "credentials" : [ {
+              "type" : "password",
+              "value" : "123"
+        } ],
+        "clientRoles": {
+            "account": ["view-profile", "manage-account"]
+        },
+        "groups" : [
+          "users"
+        ],
+        "attributes" : {
+          "id" : "SyVXyMuSr",
+          "name" : "Billy Baller",
+          "position" : "Junior Truck Driver",
+          "phone" : "2653111527",
+          "notes" : "Bill doesn't work during the weekends.",
+          "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/peterme/128.jpg",
+          "banner" : "https://s3-eu-west-1.amazonaws.com/raincatcher-files/Screen+Shot+2017-03-27+at+11.04.27.png"
+      }
+    },
+    {
+        "username" : "sally",
+        "enabled": true,
+        "email" : "sallys@wfm.com",
+        "firstName": "Sally",
+        "lastName": "Shorer",
+        "credentials" : [ {
+              "type" : "password",
+              "value" : "123"
+        } ],
+        "clientRoles": {
+            "account": ["view-profile", "manage-account"]
+        },
+        "groups" : [
+          "users"
+        ],
+        "attributes" : {
+          "id" : "B1r71fOBr",
+          "name" : "Sally Shorer",
+          "position" : "Junior Truck Driver",
+          "phone" : "2653893496",
+          "notes" : "Sally doesn't work during the weekends.",
+          "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/kfriedson/128.jpg",
+          "banner" : "https://s3-eu-west-1.amazonaws.com/raincatcher-files/Screen+Shot+2017-03-27+at+11.04.27.png"
+      }
+    },
+    {
+        "username" : "danny",
+        "enabled": true,
+        "email" : "dannyd@wfm.com",
+        "firstName": "Danny",
+        "lastName": "Doorman",
+        "credentials" : [ {
+              "type" : "password",
+              "value" : "123"
+        } ],
+        "clientRoles": {
+            "account": ["view-profile", "manage-account"]
+        },
+        "groups" : [
+          "users"
+        ],
+        "attributes" : {
+          "id" : "HJ8QkzOSH",
+          "name" : "Danny Doorman",
+          "position" : "Junior Truck Driver",
+          "phone" : "2654472304",
+          "notes" : "Danny doesn't work during the weekends.",
+          "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/danbenoni/128.jpg",
+          "banner" : "https://s3-eu-west-1.amazonaws.com/raincatcher-files/Screen+Shot+2017-03-27+at+11.04.27.png"
+      }
+    },
+    {
+        "username" : "john",
+        "enabled": true,
+        "email" : "johnf@wfm.com",
+        "firstName": "Johnny",
+        "lastName": "Fizall",
+        "credentials" : [ {
+              "type" : "password",
+              "value" : "123"
+        } ],
+        "clientRoles": {
+            "account": ["view-profile", "manage-account"]
+        },
+        "groups" : [
+          "users"
+        ],
+        "attributes" : {
+          "id" : "BJQm1G_BS",
+          "name" : "Johnny Fizall",
+          "position" : "Junior Truck Driver",
+          "phone" : "2657211126",
+          "notes" : "Johnny doesn't work during the weekends.",
+          "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/jfkingsley/128.jpg",
+          "banner" : "https://s3-eu-west-1.amazonaws.com/raincatcher-files/Screen+Shot+2017-03-27+at+11.04.27.png"
+      }
+    },
+    {
+        "username" : "phylis",
+        "enabled": true,
+        "email" : "phylis@wfm.com",
+        "firstName": "Phylis",
+        "lastName": "Lexy",
+        "credentials" : [ {
+              "type" : "password",
+              "value" : "123"
+        } ],
+        "clientRoles": {
+            "account": ["view-profile", "manage-account"]
+        },
+        "groups" : [
+          "admins"
+        ],
+        "attributes" : {
+          "id" : "ByzQyz_BS",
+          "name" : "Phylis Lexy",
+          "position" : "Phone Support",
+          "phone" : "2657343446",
+          "notes" : "Phylis doesn't work during the weekends.",
+          "avatar" : "https://s3.amazonaws.com/uifaces/faces/twitter/ladylexy/128.jpg",
+          "banner" : "https://s3-eu-west-1.amazonaws.com/raincatcher-files/Screen+Shot+2017-03-27+at+11.04.27.png"
+      }
+    }
+    ],
+    "clients": [
+        {
+            "clientId": "raincatcher-cloud",
+            "enabled": true,
+            "bearerOnly": true
+        },
+        {
+            "clientId": "raincatcher-portal",
+            "enabled": true,
+            "publicClient": true,
+            "redirectUris": [
+                "*"
+            ],
+            "webOrigins": ["*"]
+        },
+        {
+            "clientId": "raincatcher-mobile",
+            "enabled": true,
+            "publicClient": true,
+            "redirectUris": [
+                "*"
+            ],
+            "webOrigins": ["*"]
+        }
+    ],
+    "clientScopeMappings": {
+        "account": [
+            {
+                "client": "raincatcher-cloud",
+                "roles": ["view-profile"]
+            },
+            {
+                "client": "raincatcher-mobile",
+                "roles": ["view-profile"]
+            },
+            {
+                "client": "raincatcher-portal",
+                "roles": ["view-profile"]
+            }
+        ]
+    },
+    "roles" : {
+        "client" : {
+          "raincatcher-cloud" : [{
+          "name" : "admin",
+          "scopeParamRequired" : false,
+          "composite" : false,
+          "clientRole" : true
+        }, 
+        {
+          "name" : "user",
+          "scopeParamRequired" : false,
+          "composite" : false,
+          "clientRole" : true
+        }],
+        "raincatcher-portal" : [{
+        "name" : "admin",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true
+      }],
+        "raincatcher-mobile" : [{
+        "name" : "user",
+        "scopeParamRequired" : false,
+        "composite" : false,
+        "clientRole" : true
+      }]
+     }
+  },
+  "groups": [
+    {
+      "id": "d991edd4-4130-4635-8514-2660c449b126",
+      "name": "users",
+      "path": "/users",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {
+        "raincatcher-mobile": [
+          "user"
+        ],
+        "raincatcher-cloud": [
+          "user"
+        ]
+      },
+      "subGroups": []
+    },
+    {
+      "id": "93fecdd9-6685-4b5a-b7c3-617a1c039419",
+      "name": "admins",
+      "path": "/admins",
+      "attributes": {},
+      "realmRoles": [],
+      "clientRoles": {
+        "raincatcher-mobile": [
+          "user"
+        ],
+        "raincatcher-portal": [
+          "admin"
+        ],
+        "raincatcher-cloud": [
+          "admin",
+          "user"
+        ]
+      },
+      "subGroups": []
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation
We should move the raincatcher keycloak realm file within the core templates to make it available to use with a keycloak image. 

## Description
Move raincatcher-realm.json file from the raincatcher-keycloak repo to the core templates. 

## Progress
- [x] Move raincatcher-realm.json file to the core templates

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1263
