### PR TITLE
[RAINCATCH-1249] Allow to revert to NEW status when backing

### DIFF
--- a/client/wfm/src/service/WfmService.ts
+++ b/client/wfm/src/service/WfmService.ts
@@ -92,6 +92,10 @@ export class WfmService {
         // Previous step might be undefined if index-1 < 0
         workorder.currentStep = previousStep && previousStep.id;
       }
+      // if there's no longer a current step, we've backed into NEW status
+      if (!workorder.currentStep) {
+        workorder.status = STATUS.NEW;
+      }
 
       return this.workorderService.update(workorder);
     });

--- a/client/wfm/test/mocks/MockWorkOrder.ts
+++ b/client/wfm/test/mocks/MockWorkOrder.ts
@@ -2,6 +2,7 @@ import * as Promise from 'bluebird';
 import { DataService, STATUS, WorkOrder } from '../../src/index';
 import { MockDataService } from './MockDataService';
 import { steps } from './MockStepData';
+import { fixtures as workflows } from './MockWorkFlow';
 
 const fixtures: WorkOrder[] = [
   {
@@ -13,14 +14,7 @@ const fixtures: WorkOrder[] = [
     version: 1,
     created: 0,
     updated: 0,
-    workflow: {
-      id: 'SyVXyMuSr',
-      version: 1,
-      title: 'Vehicle Accident Workflow',
-      steps,
-      created: 0,
-      updated: 0
-    }
+    workflow: workflows[1]
   },
   {
     id: 'in-progress-workorder',
@@ -32,28 +26,19 @@ const fixtures: WorkOrder[] = [
     version: 1,
     created: 0,
     updated: 0,
-    workflow: {
-      id: 'SyVXyMuSr',
-      version: 1,
-      title: 'Vehicle Accident Workflow',
-      steps,
-      created: 0,
-      updated: 0
-    }
+    workflow: workflows[1]
   },
   {
     id: 'second-step-workorder',
     assignee: 'rkX1fdSH',
     title: 'Accident No. 3041',
     status: STATUS.PENDING,
+    version: 1,
+    created: 0,
+    updated: 0,
     currentStep: steps[1].id,
     results: [],
-    workflow: {
-      id: 'SyVXyMuSr',
-      version: 1,
-      title: 'Vehicle Accident Workflow',
-      steps
-    }
+    workflow: workflows[1]
   },
   {
     id: 'complete-workorder',
@@ -85,14 +70,7 @@ const fixtures: WorkOrder[] = [
         timestamp: 1504800162822
       }
     ],
-    workflow: {
-      id: 'SyVXyMuSr',
-      version: 1,
-      title: 'Vehicle Accident Workflow',
-      steps,
-      created: 0,
-      updated: 0
-    }
+    workflow: workflows[1]
   },
   {
     id: 'no-steps-workorder',
@@ -120,14 +98,7 @@ const fixtures: WorkOrder[] = [
     created: 0,
     updated: 0,
     results: [],
-    workflow: {
-      id: 'SyVXyMuSr',
-      version: 1,
-      title: 'Vehicle Accident Workflow',
-      steps,
-      created: 0,
-      updated: 0
-    }
+    workflow: workflows[1]
   }
 ];
 const mockWorkorderService = new MockDataService<WorkOrder>(fixtures);

--- a/client/wfm/test/mocks/MockWorkOrder.ts
+++ b/client/wfm/test/mocks/MockWorkOrder.ts
@@ -42,6 +42,20 @@ const fixtures: WorkOrder[] = [
     }
   },
   {
+    id: 'second-step-workorder',
+    assignee: 'rkX1fdSH',
+    title: 'Accident No. 3041',
+    status: STATUS.PENDING,
+    currentStep: steps[1].id,
+    results: [],
+    workflow: {
+      id: 'SyVXyMuSr',
+      version: 1,
+      title: 'Vehicle Accident Workflow',
+      steps
+    }
+  },
+  {
     id: 'complete-workorder',
     assignee: 'rkX1fdSH',
     title: 'Accident No. 3041',

--- a/client/wfm/test/service/WfmService-spec.ts
+++ b/client/wfm/test/service/WfmService-spec.ts
@@ -62,6 +62,21 @@ describe('WfmService', function() {
     });
   });
 
+  describe('#previousStep', function() {
+    it('should move to the previous step', function() {
+      return subject.previousStep('second-step-workorder')
+        .then(workorder => expect(workorder.currentStep).to.equal(workorder.workflow.steps[0].id));
+    });
+    it('should reset status to new when moving back from the first step', function() {
+      return subject.previousStep('in-progress-workorder')
+        .then(workorder => {
+          // tslint:disable-next-line:no-unused-expression
+          expect(workorder.currentStep).to.be.undefined;
+          expect(workorder.status).to.equal(STATUS.NEW);
+        });
+    });
+  });
+
   describe('#getStepForResult', function() {
     it('should get the right step', function() {
       return subject.readWorkOrder('complete-workorder')


### PR DESCRIPTION
## Motivation
Previously we wouldn't be allowed by the UI to resume a workorder that was backed into the first step. It was considered a UI bug but can also be fixed if we allow workorders to go back into the NEW state.

## Description
- Add branch to return workorder to new state

## Progress
- [X] Go back into NEW status if calling previousStep() on first step
- [x] Unit tests


