### PR TITLE
[RAINCATCH-623] Use fh-sync clearCache on logout

### DIFF
--- a/client/datasync-client/src/DataManager.ts
+++ b/client/datasync-client/src/DataManager.ts
@@ -138,7 +138,7 @@ export class DataManager {
     const self = this;
     return new Bluebird(function(resolve, reject) {
       syncApi.stopSync(self.datasetId, function() {
-        return resolve();
+        resolve();
       }, function(error) {
         return reject(new Error(error));
       });
@@ -179,7 +179,7 @@ export class DataManager {
     const options = _.defaults(userOptions, defaultOptions);
     function forceSyncThenStop(pendingUpdateQueueSize) {
       if (pendingUpdateQueueSize === 0) {
-        return self.stop().then(Bluebird.resolve);
+        return Bluebird.resolve(self.stop());
       }
       // Steps: force sync, wait, check if results were synced back, stop server
       return self.forceSync()
@@ -213,8 +213,7 @@ export class DataManager {
    * Clears the cache for the dataset
    */
   public clearCache() {
-    const self = this;
-    return syncApi.clearCache(self.datasetId);
+    return syncApi.clearCache(this.datasetId);
   }
 
   /**

--- a/client/datasync-client/src/DataManager.ts
+++ b/client/datasync-client/src/DataManager.ts
@@ -138,9 +138,9 @@ export class DataManager {
     const self = this;
     return new Bluebird(function(resolve, reject) {
       syncApi.stopSync(self.datasetId, function() {
-        resolve();
+        return resolve();
       }, function(error) {
-        reject(new Error(error));
+        return reject(new Error(error));
       });
     });
   }
@@ -179,8 +179,7 @@ export class DataManager {
     const options = _.defaults(userOptions, defaultOptions);
     function forceSyncThenStop(pendingUpdateQueueSize) {
       if (pendingUpdateQueueSize === 0) {
-        self.stop().then(Bluebird.resolve);
-        return;
+        return self.stop().then(Bluebird.resolve);
       }
       // Steps: force sync, wait, check if results were synced back, stop server
       return self.forceSync()
@@ -208,6 +207,14 @@ export class DataManager {
         dataUpdated();
       }
     });
+  }
+
+  /**
+   * Clears the cache for the dataset
+   */
+  public clearCache() {
+    const self = this;
+    return syncApi.clearCache(self.datasetId);
   }
 
   /**

--- a/client/datasync-client/test/DataManagerTest.ts
+++ b/client/datasync-client/test/DataManagerTest.ts
@@ -246,7 +246,8 @@ describe('Data Manager', function() {
     const results = [];
     const mock$fh = {
       forceSync: sinon.stub().callsArgWith(1),
-      getPending: sinon.stub().callsArgWith(1, results)
+      getPending: sinon.stub().callsArgWith(1, results),
+      stopSync: sinon.stub().callsArgWith(1)
     };
 
     const DataManager = proxyquire.noCallThru().load('../src/DataManager', {


### PR DESCRIPTION
## Motivation
In the mobile app, the previous logged in user's data is shown upon login. We need to clear sync cache to prevent this.

## Description
Utilize fh-sync's clearCache function to allow cache to be cleared upon logout.

## Progress
- [x]  Add clearCache functionality that uses fh-syncs clearCache

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-623