### PR TITLE
Remove init from interface

### DIFF
--- a/cloud/auth/src/EndpointSecurity.ts
+++ b/cloud/auth/src/EndpointSecurity.ts
@@ -8,14 +8,6 @@ import { SessionOptions } from 'express-session';
 export interface EndpointSecurity {
 
   /**
-   * Initializes an Express application to use passport and express-session
-   *
-   * @param app - An express application
-   * @param sessionOpts - Session options to be used by express-session
-   */
-  init(app: express.Express, sessionOpts: SessionOptions): void;
-
-  /**
    * Function which checks if the user requesting access to the resource is authenticated and authorized to
    * access the resource. Redirects to the login page if user is not authenticated or returns a status of 403
    * if the user does not have the required role.


### PR DESCRIPTION
After reviewing code I found that init method it's not used anymore. 
We use different variations of init and that directly.
 

Posting to share opinions.