### PR TITLE
[RAINCATCH-1180] Hide Completed Workorders

### DIFF
--- a/client/wfm/src/model/WorkOrder.ts
+++ b/client/wfm/src/model/WorkOrder.ts
@@ -6,6 +6,12 @@ import { WorkFlow } from './WorkFlow';
 
 type LatLng = [number, number];
 
+interface HistoryEntry {
+  before: STATUS | string;
+  after: STATUS | string;
+  timestamp: number;
+}
+
 /**
  * The executable instance of a {@link WorkFlow}
  */
@@ -69,4 +75,6 @@ export interface WorkOrder {
    * Timestamp of this WorkOrder's last update
    */
   updated: number;
+
+  statusHistory?: HistoryEntry[];
 }

--- a/client/wfm/src/model/WorkOrder.ts
+++ b/client/wfm/src/model/WorkOrder.ts
@@ -6,12 +6,6 @@ import { WorkFlow } from './WorkFlow';
 
 type LatLng = [number, number];
 
-interface HistoryEntry {
-  before: STATUS | string;
-  after: STATUS | string;
-  timestamp: number;
-}
-
 /**
  * The executable instance of a {@link WorkFlow}
  */
@@ -76,5 +70,16 @@ export interface WorkOrder {
    */
   updated: number;
 
-  statusHistory?: HistoryEntry[];
+  /**
+   * List of timestamps of when this WorkOrder last reached a given {@link STATUS}
+   *
+   * @example
+   * {
+   *   'New': 1506010024468,
+   *   'Complete': 1506010024468
+   * }
+   */
+  statusHistory?: {
+    [status: string]: number
+  };
 }

--- a/client/wfm/src/service/WfmService.ts
+++ b/client/wfm/src/service/WfmService.ts
@@ -196,12 +196,8 @@ export class WfmService {
   }
 
   protected setWorkOrderStatus(workorder: WorkOrder, status: STATUS) {
-    workorder.statusHistory = workorder.statusHistory || [];
-    workorder.statusHistory.push({
-      before: workorder.status,
-      after: status,
-      timestamp: new Date().getTime()
-    });
+    workorder.statusHistory = workorder.statusHistory || {};
+    workorder.statusHistory[status] = new Date().getTime();
     workorder.status = status;
   }
 }

--- a/client/wfm/src/service/WfmService.ts
+++ b/client/wfm/src/service/WfmService.ts
@@ -28,7 +28,7 @@ export class WfmService {
     if (!workorder.assignee) {
       throw new Error(`Workorder with Id ${workorder.id} has no assignee and cannot be started`);
     }
-    workorder.status = STATUS.PENDING;
+    this.setWorkOrderStatus(workorder, STATUS.PENDING);
     workorder.currentStep = workorder.workflow.steps[0].id;
     workorder.results = [];
     return this.workorderService.update(workorder);
@@ -94,7 +94,7 @@ export class WfmService {
       }
       // if there's no longer a current step, we've backed into NEW status
       if (!workorder.currentStep) {
-        workorder.status = STATUS.NEW;
+        this.setWorkOrderStatus(workorder, STATUS.NEW);
       }
 
       return this.workorderService.update(workorder);
@@ -188,10 +188,20 @@ export class WfmService {
     }
     // if current is the last, workorder is now complete
     if (index === workorder.workflow.steps.length - 1) {
-      workorder.status = STATUS.COMPLETE;
+      this.setWorkOrderStatus(workorder, STATUS.COMPLETE);
       return workorder.currentStep = undefined;
     }
     const nextStep = workorder.workflow.steps[index + 1];
     return workorder.currentStep = nextStep && nextStep.id;
+  }
+
+  protected setWorkOrderStatus(workorder: WorkOrder, status: STATUS) {
+    workorder.statusHistory = workorder.statusHistory || [];
+    workorder.statusHistory.push({
+      before: workorder.status,
+      after: status,
+      timestamp: new Date().getTime()
+    });
+    workorder.status = status;
   }
 }

--- a/client/wfm/test/service/WfmService-spec.ts
+++ b/client/wfm/test/service/WfmService-spec.ts
@@ -42,6 +42,8 @@ describe('WfmService', function() {
         .then(workorder => subject.begin(workorder))
         .then(workorder => {
           expect(workorder.status).to.equal(STATUS.PENDING);
+          // tslint:disable-next-line:no-unused-expression
+          expect(workorder.statusHistory && workorder.statusHistory[STATUS.PENDING]).to.exist;
           expect(workorder.currentStep).to.equal(workorder.workflow.steps[0].id);
         });
     });

--- a/demo/server/README.md
+++ b/demo/server/README.md
@@ -39,3 +39,11 @@ For example:
 process.env.CONFIG_PROFILE === 'prod'
 // it will load config-prod.js file in top level application
 ```
+
+### Configuring custom query parameters for mobile clients
+
+Mobile clients based on the sync framework might not require to receive all WorkOrders in order to operate.
+
+To save on local memory usage, data traffic and improve performance, additional filters can be added to limit those.
+
+In this sample implementation, WorkOrders that are in a complete state stop being sent to mobile clients after two days of their completion. This can be configured via the `sync.daysToExcludeCompleteWorkorders` configuration key. It illustrates a way to include a relatively complex MongoDB query filter into the chain that is used by the list handler for the sync framework.

--- a/demo/server/config-dev.js
+++ b/demo/server/config-dev.js
@@ -55,7 +55,13 @@ var config = {
   "sync": {
     // Required to handle UI.
     "customDataHandlers": true,
-    "excludeOldCompleteWorkOrders": 2
+    /**
+     * Specify that completed WorkOrders over a given number of days must be excluded from listings
+     * sent to mobile clients. Use -1 to deactivate this feature
+     *
+     * Only works if {@link customDataHandlers} is true
+     */
+    "daysToExcludeCompleteWorkorders": 2
   },
   // See bunyan.d.ts/LoggerOptions
   "bunyanConfig": {

--- a/demo/server/config-dev.js
+++ b/demo/server/config-dev.js
@@ -54,7 +54,8 @@ var config = {
   },
   "sync": {
     // Required to handle UI.
-    "customDataHandlers": true
+    "customDataHandlers": true,
+    "excludeOldCompleteWorkOrders": 2
   },
   // See bunyan.d.ts/LoggerOptions
   "bunyanConfig": {

--- a/demo/server/config-prod.js
+++ b/demo/server/config-prod.js
@@ -55,7 +55,8 @@ var config = {
   },
   "sync": {
     // Required to handle UI.
-    "customDataHandlers": true
+    "customDataHandlers": true,
+    "excludeOldCompleteWorkOrders": 2
   },
   // See bunyan.d.ts/LoggerOptions
   "bunyanConfig": {

--- a/demo/server/config-prod.js
+++ b/demo/server/config-prod.js
@@ -56,7 +56,13 @@ var config = {
   "sync": {
     // Required to handle UI.
     "customDataHandlers": true,
-    "excludeOldCompleteWorkOrders": 2
+    /**
+     * Specify that completed WorkOrders over a given number of days must be excluded from listings
+     * sent to mobile clients. Use -1 to deactivate this feature
+     *
+     * Only works if {@link customDataHandlers} is true
+     */
+    "daysToExcludeCompleteWorkorders": 2
   },
   // See bunyan.d.ts/LoggerOptions
   "bunyanConfig": {

--- a/demo/server/src/modules/datasync/Connector.ts
+++ b/demo/server/src/modules/datasync/Connector.ts
@@ -38,8 +38,8 @@ export function connect() {
       }
       if (config.sync.customDataHandlers) {
         const handler = new GlobalMongoDataHandler(mongo);
-        const excludeDays = appConfig.getConfig().sync.excludeOldCompleteWorkOrders;
-        if (excludeDays > 0) {
+        const excludeDays = appConfig.getConfig().sync.daysToExcludeCompleteWorkorders;
+        if (excludeDays > -1) {
           handler.addListFilterModifier(excludeCompleteWorkOrders(excludeDays));
         }
         handler.initGlobalHandlers();

--- a/demo/server/src/modules/datasync/Connector.ts
+++ b/demo/server/src/modules/datasync/Connector.ts
@@ -2,6 +2,7 @@ import SyncServer, { SyncApi, SyncExpressMiddleware, SyncOptions } from '@rainca
 import { getLogger } from '@raincatcher/logger';
 import * as Promise from 'bluebird';
 import appConfig from '../../util/Config';
+import { excludeCompleteWorkOrders } from './filters/ExcludeCompletedWorkorders';
 import { GlobalMongoDataHandler } from './MongoDataHandler';
 
 const sync = SyncServer;
@@ -13,7 +14,7 @@ process.env.DEBUG = 'fh-mbaas-api:sync';
 // Sync connection options
 const connectOptions: SyncOptions = {
   datasetConfiguration: {
-    mongoDbConnectionUrl:  appConfig.getConfig().mongodb.url,
+    mongoDbConnectionUrl: appConfig.getConfig().mongodb.url,
     mongoDbOptions: appConfig.getConfig().mongodb.options,
     redisConnectionUrl: appConfig.getConfig().redis.url
   },
@@ -37,6 +38,10 @@ export function connect() {
       }
       if (config.sync.customDataHandlers) {
         const handler = new GlobalMongoDataHandler(mongo);
+        const excludeDays = appConfig.getConfig().sync.excludeOldCompleteWorkOrders;
+        if (excludeDays > 0) {
+          handler.addListFilterModifier(excludeCompleteWorkOrders(excludeDays));
+        }
         handler.initGlobalHandlers();
       }
       return resolve({ mongo, redis });

--- a/demo/server/src/modules/datasync/filters/ExcludeCompletedWorkorders.ts
+++ b/demo/server/src/modules/datasync/filters/ExcludeCompletedWorkorders.ts
@@ -1,0 +1,23 @@
+/**
+ * Excludes WorkOrders with a Complete date over a set number of days ago
+ * @param queryParams
+ */
+export function excludeCompleteWorkOrders(days: number) {
+  if (days < 0) {
+    throw new Error(`Days must be a number greater than or equal to zero, got ${days}`);
+  }
+  return function(queryParams: any) {
+    const daysAgo = new Date();
+    daysAgo.setDate(daysAgo.getDate() - days);
+    const excludeQuery = {
+      '$or': [
+        { 'statusHistory.Complete': { '$exists': false } },
+        { 'statusHistory.Complete': { '$gt': daysAgo.getTime() } }
+      ]
+    };
+
+    // Add this query to $and so it doesn't overwrite other queries
+    queryParams.$and = queryParams.$and || [];
+    queryParams.$and.push(excludeQuery);
+  };
+}

--- a/demo/server/src/modules/datasync/filters/filterModifier.ts
+++ b/demo/server/src/modules/datasync/filters/filterModifier.ts
@@ -1,0 +1,3 @@
+export type FilterModifier {
+  (params: any): any
+}

--- a/demo/server/src/modules/datasync/filters/filterModifier.ts
+++ b/demo/server/src/modules/datasync/filters/filterModifier.ts
@@ -1,3 +1,0 @@
-export type FilterModifier {
-  (params: any): any
-}

--- a/demo/server/src/util/Config.ts
+++ b/demo/server/src/util/Config.ts
@@ -73,6 +73,13 @@ export interface CloudAppConfig {
   };
   sync: {
     customDataHandlers: boolean;
+    /**
+     * Specify that completed WorkOrders over a given number of days must be excluded from listings
+     * sent to mobile clients
+     *
+     * Only works if {@link customDataHandlers} is true
+     */
+    excludeOldCompleteWorkOrders: number;
     globalOptions: SyncGlobalParameters;
   };
   mongodb: {

--- a/demo/server/src/util/Config.ts
+++ b/demo/server/src/util/Config.ts
@@ -75,11 +75,11 @@ export interface CloudAppConfig {
     customDataHandlers: boolean;
     /**
      * Specify that completed WorkOrders over a given number of days must be excluded from listings
-     * sent to mobile clients
+     * sent to mobile clients. Use -1 to deactivate this feature
      *
      * Only works if {@link customDataHandlers} is true
      */
-    excludeOldCompleteWorkOrders: number;
+    daysToExcludeCompleteWorkorders: number;
     globalOptions: SyncGlobalParameters;
   };
   mongodb: {


### PR DESCRIPTION
## Motivation
Stop syncing old completed workorders to the mobile client to avoid data clutter and excess data flow.
Keep workorders available for the portal.

## Description
- Add tracking for workorder status
- Add extensibility option for server-side mongodb list filter
- Add filter+configuration for excluding workorders completed X days ago

## Progress
- [X] History tracking
- [X] custom list filters
- [X] completed workorder filter
- [X] Unit tests