### PR TITLE
Add profile filter for passport

### DIFF
--- a/cloud/passportauth/example/UserRepository.ts
+++ b/cloud/passportauth/example/UserRepository.ts
@@ -24,6 +24,9 @@ const userSeedData = [
  * A sample user service implementation
  */
 export class SampleUserService implements UserService {
+  public getProfile(user: any) {
+    return user;
+  }
   public validatePassword(user: any, password: string) {
     return user.password === password;
   }

--- a/cloud/passportauth/src/auth/DefaultStrategies.ts
+++ b/cloud/passportauth/src/auth/DefaultStrategies.ts
@@ -14,12 +14,10 @@ export const webStrategy = (userRepo: UserRepository, userService: UserService) 
   return (loginId: string, password: string, done: (error: Error | null, user: any) => any) => {
     const callback = (err?: Error, user?: any) => {
       if (user && userService.validatePassword(user, password)) {
-        return done(null, user);
+        return done(null, userService.getProfile(user));
       }
-
       return err ? done(err, false) : done(null, false);
     };
-
     userRepo.getUserByLogin(loginId, callback);
   };
 };

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -134,7 +134,8 @@ export class PassportAuth implements EndpointSecurity {
           if (user && userService.validatePassword(user, req.body.password)) {
             const payload = req.body.username;
             const token = jwt.sign(payload, secret);
-            return res.status(200).json({ 'token': token, 'profile': user });
+            const profile = userService.getProfile(user);
+            return res.status(200).json({ 'token': token, 'profile': profile });
           }
           return res.status(401).send();
         };

--- a/cloud/passportauth/src/user/UserService.ts
+++ b/cloud/passportauth/src/user/UserService.ts
@@ -23,7 +23,14 @@ export interface UserService {
    * @param role - The role required to access a resource
    * @returns {boolean} - Returns true/false if the user is authorized to access a resource
    */
-  hasResourceRole(user: any, role: string|undefined): boolean;
+  hasResourceRole(user: any, role: string | undefined): boolean;
+
+  /**
+   * Returns profile data for the user
+   * Function should be used to filter out data that should not be returned to the client.
+   * For example password hash.
+   */
+  getProfile(user: any): any;
 }
 
 export default UserService;

--- a/cloud/passportauth/test/mocks/MockUserRepo.ts
+++ b/cloud/passportauth/test/mocks/MockUserRepo.ts
@@ -1,10 +1,13 @@
 import { UserRepository, UserService } from '../../src/index';
 
 export const mockUserService: UserService = {
+  getProfile(user: any) {
+    return user;
+  },
   validatePassword(user: any, password: string) {
     return user.password === password;
   },
-  hasResourceRole(user: any, roleRequired: string|undefined) {
+  hasResourceRole(user: any, roleRequired: string | undefined) {
     if (roleRequired) {
       return user.roles.indexOf(roleRequired) > -1;
     } else {

--- a/demo/server/src/modules/passport-auth/DemoUserRepository.ts
+++ b/demo/server/src/modules/passport-auth/DemoUserRepository.ts
@@ -24,8 +24,9 @@ export class SampleUserService implements UserService {
     }
   }
   public getProfile(user: any) {
-    delete user.password;
-    return user;
+    const profileData = _.cloneDeep(user);
+    delete profileData.password;
+    return profileData;
   }
 }
 

--- a/demo/server/src/modules/passport-auth/DemoUserRepository.ts
+++ b/demo/server/src/modules/passport-auth/DemoUserRepository.ts
@@ -13,21 +13,19 @@ export const users: any[] = require('./users.json');
  * Note: This implementation is only for demo purposes.
  */
 export class SampleUserService implements UserService {
-  // Map user object
-  public getLoginId(user: any) {
-    return user.username;
-  }
-
   public validatePassword(user: any, password: string) {
     return user.password === password;
   }
-
-  public hasResourceRole(user: any, role: string|undefined) {
+  public hasResourceRole(user: any, role: string | undefined) {
     if (role) {
       return user.roles.indexOf(role) > -1;
     } else {
       return true;
     }
+  }
+  public getProfile(user: any) {
+    delete user.password;
+    return user;
   }
 }
 


### PR DESCRIPTION
## Motivation

Allow passport framework to filer out user data (including passport) when returning results to client.
<img width="1870" alt="screen shot 2017-09-30 at 5 23 39 pm" src="https://user-images.githubusercontent.com/981838/31047522-50cf106e-a604-11e7-922b-0b80f69d5618.png">

- [x] Implement check
- [x] Add example
- [x] Add support to demo app
- [x] Testing
