### PR TITLE
[RHMAP-18044] downgrade connect-redis version

### DIFF
--- a/cloud/wfm-rest-api/src/data-api/PagingDataRepository.ts
+++ b/cloud/wfm-rest-api/src/data-api/PagingDataRepository.ts
@@ -31,20 +31,20 @@ export interface PagingDataRepository<T> {
    * Get specific item from database
    * @param id - object id
    */
-  get(id: string): Promise<T>;
+  get(id: string): Promise<T|undefined>;
 
   /**
    * Store object in database
    * @param object - object to store
    */
-  create(object: T): Promise<T>;
+  create(object: T): Promise<T|undefined>;
 
   /**
    * Update object
    * @param object - object to update
    * Note: id field of the object will be used to determine what should be updated
    */
-  update(object: T): Promise<T>;
+  update(object: T): Promise<T|undefined>;
 
   /**
    * Delete object from database

--- a/cloud/wfm-rest-api/src/data-api/PagingDataRepository.ts
+++ b/cloud/wfm-rest-api/src/data-api/PagingDataRepository.ts
@@ -31,20 +31,20 @@ export interface PagingDataRepository<T> {
    * Get specific item from database
    * @param id - object id
    */
-  get(id: string): Promise<T|undefined>;
+  get(id: string): Promise<T|null>;
 
   /**
    * Store object in database
    * @param object - object to store
    */
-  create(object: T): Promise<T|undefined>;
+  create(object: T): Promise<T|null>;
 
   /**
    * Update object
    * @param object - object to update
    * Note: id field of the object will be used to determine what should be updated
    */
-  update(object: T): Promise<T|undefined>;
+  update(object: T): Promise<T|null>;
 
   /**
    * Delete object from database

--- a/cloud/wfm-rest-api/src/impl/MongoDbRepository.ts
+++ b/cloud/wfm-rest-api/src/impl/MongoDbRepository.ts
@@ -45,14 +45,14 @@ export class MongoDbRepository<T extends {
     }
   }
 
-  public get(id: string): Bluebird<T> {
+  public get(id: string): Bluebird<T|undefined> {
     if (!this.db) {
       return Bluebird.reject(dbError);
     }
     return Bluebird.resolve(this.collection.findOne({ id })).catch(this.handleError);
   }
 
-  public create(object: T): Bluebird<T> {
+  public create(object: T): Bluebird<T|undefined> {
     object.id = object.id || generate();
     if (!this.db) {
       return Bluebird.reject(dbError);
@@ -64,7 +64,7 @@ export class MongoDbRepository<T extends {
       .catch(this.handleError);
   }
 
-  public update(object: T): Bluebird<T> {
+  public update(object: T): Bluebird<T|undefined> {
     if (!this.db) {
       return Bluebird.reject(dbError);
     }

--- a/cloud/wfm-rest-api/src/impl/MongoDbRepository.ts
+++ b/cloud/wfm-rest-api/src/impl/MongoDbRepository.ts
@@ -45,14 +45,14 @@ export class MongoDbRepository<T extends {
     }
   }
 
-  public get(id: string): Bluebird<T|undefined> {
+  public get(id: string): Bluebird<T|null> {
     if (!this.db) {
       return Bluebird.reject(dbError);
     }
     return Bluebird.resolve(this.collection.findOne({ id })).catch(this.handleError);
   }
 
-  public create(object: T): Bluebird<T|undefined> {
+  public create(object: T): Bluebird<T|null> {
     object.id = object.id || generate();
     if (!this.db) {
       return Bluebird.reject(dbError);
@@ -64,7 +64,7 @@ export class MongoDbRepository<T extends {
       .catch(this.handleError);
   }
 
-  public update(object: T): Bluebird<T|undefined> {
+  public update(object: T): Bluebird<T|null> {
     if (!this.db) {
       return Bluebird.reject(dbError);
     }

--- a/demo/server/config-dev.js
+++ b/demo/server/config-dev.js
@@ -25,8 +25,9 @@ var config = {
     /// Redis session store configuration
     // https://github.com/tj/connect-redis
     "redisStore": {
-      "url": getRedisUrl(),
-      "prefix": "rc-session:",
+      "host": getRedisHost(),
+      "port": getRedisPort(),
+      "prefix": "rcsession:",
       "logErrors": true
     },
     // Configuration for express session (used for both passport and keycloak)

--- a/demo/server/config-prod.js
+++ b/demo/server/config-prod.js
@@ -26,8 +26,9 @@ var config = {
     /// Redis session store configuration
     // https://github.com/tj/connect-redis
     "redisStore": {
-      "url": getRedisUrl(),
-      "prefix": "rc-session:",
+      "host": getRedisHost(),
+      "port": getRedisPort(),
+      "prefix": "rcsession:",
       "logErrors": true
     },
     // Configuration for express session (used for both passport and keycloak)

--- a/demo/server/package.json
+++ b/demo/server/package.json
@@ -69,7 +69,7 @@
     "@raincatcher/wfm-user": "0.0.5",
     "bluebird": "^3.5.0",
     "body-parser": "^1.17.2",
-    "connect-redis": "^3.3.0",
+    "connect-redis": "3.0.0",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.4",
     "express": "^4.15.4",


### PR DESCRIPTION
## Motivation
Fixing redirection issues in portal.
We need to adjust version to work with the wider range of the supported redis versions.

## Description
Use older version of connect-redis 3.3.0. 

## Progress
- [x] Update version of connect-redis to use 3.3.0

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RHMAP-18044
