### PR TITLE
[RAINCATCH-1344] Fix compilation issues on top of the published packages

### DIFF
--- a/cloud/datasync/src/web/SyncMapperMiddleware.ts
+++ b/cloud/datasync/src/web/SyncMapperMiddleware.ts
@@ -16,7 +16,7 @@ const logger = getLogger();
  * @param explicit - reject other query parameters and filter only by user field
  */
 export function userMapperMiddleware(dataset: string, fieldName: string, explicit?: boolean) {
-  const middleware = function(req: express.Request, res: express.Response, next) {
+  const middleware = function(req: any, res: express.Response, next) {
     // Execute only when session contains user information
     if (req.user) {
       if (req.body.dataset_id === dataset && req.body.query_params) {

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -62,7 +62,7 @@ export class PassportAuth implements EndpointSecurity {
    */
   public protect(role?: string) {
     const self = this;
-    return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return (req: any, res: express.Response, next: express.NextFunction) => {
       if (req.headers && req.headers.authorization) {
         getLogger().info('Token based authentication and authorization');
         return self.passport.authenticate('jwt', { session: false }, function(err, user) {
@@ -104,7 +104,7 @@ export class PassportAuth implements EndpointSecurity {
    */
   public authenticate(strategy: string, options?: AuthenticateOptions) {
     const self = this;
-    return (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    return (req: any, res: express.Response, next: express.NextFunction) => {
       if (!req.headers.authorization && req.isAuthenticated() && req.session) {
         const redirectUrl = req.session.returnTo || req.session.clientURL;
         if (redirectUrl) {
@@ -152,7 +152,7 @@ export class PassportAuth implements EndpointSecurity {
    * Handler for access denied responses in the event that a user is not authorized to access
    * a resource. This method can be overridden to provide a custom access denied handler
    */
-  protected accessDenied(req: express.Request, res: express.Response) {
+  protected accessDenied(req: any, res: express.Response) {
     res.status(403).send();
   }
 
@@ -160,7 +160,7 @@ export class PassportAuth implements EndpointSecurity {
    * Sets the url to return to after successful login.
    * This method can be overridden to provide a custom URL to return to
    */
-  protected setReturnToUrl(req: express.Request) {
+  protected setReturnToUrl(req: any) {
     if (req.headers && req.headers.referer) {
       return req.headers.referer;
     }


### PR DESCRIPTION
## Motivation
Avoid compilation issues in the published demo-server.

## Description
Replace strongly typed `express.Request` with `any` to avoid the need for `@types/passport`

This is only a workaround, a permanent solution should come as part of https://issues.jboss.org/browse/RAINCATCH-1345.
