### PR TITLE
[RAINCATCH-1323] TypeScript-specific start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ See the example on [examples/js]() for more information also for reusing the uni
 
 - `npm run test` - run unit tests
 - `npm run bootstrap` - perform boostrap for all modules
-- `npm run start` - run top level applications
-- `npm run lint` - execute tslint for all modules
 - `npm run build` - execute the build command for all modules, compiling TypeScript sources to JavaScript
+- `npm run start:ts` - run top level applications from the TypeScript sources
+- `npm run start` - run top level applications from the compile JavaScript, you must run `npm run build` before this command
+- `npm run lint` - execute tslint for all modules
 - `npm run cleanInstall` - perform install without executing additional scripts
 
 #### Publishing

--- a/client/datasync-client/package.json
+++ b/client/datasync-client/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "nyc mocha"
   },
   "nyc": {

--- a/client/wfm/package.json
+++ b/client/wfm/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del src/*.js src/*.map src/**/*.js src/**/*.map test/*.js test/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "nyc mocha",
     "debug": "node --inspect-brk ./node_modules/.bin/_mocha",
     "debug-legacy": "node --debug-brk ./node_modules/.bin/_mocha"

--- a/cloud/auth/package.json
+++ b/cloud/auth/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del src/*.js src/**/*.js src/*.map src/**/*.map test/*.js test/**/*.js test/*.map test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "npm run clean && nyc mocha",
     "example": "ts-node ./example/index.ts"
   },

--- a/cloud/passportauth/package.json
+++ b/cloud/passportauth/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del src/*.js src/**/*.js src/*.map src/**/*.map test/*.js test/**/*.js test/*.map test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "npm run clean && nyc mocha",
     "example": "ts-node ./example/index.ts"
   },

--- a/cloud/wfm-demo-data/package.json
+++ b/cloud/wfm-demo-data/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del coverage_report src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts"
   },
   "nyc": {
     "include": [

--- a/cloud/wfm-demo-data/package.json
+++ b/cloud/wfm-demo-data/package.json
@@ -8,7 +8,7 @@
   "main": "src/",
   "scripts": {
     "clean": "del coverage_report src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
-    "build": "tsc",
+    "build": "tsc"
   },
   "nyc": {
     "include": [

--- a/cloud/wfm-rest-api/package.json
+++ b/cloud/wfm-rest-api/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del coverage_report src/*.js src/*.map src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "npm run clean && nyc mocha"
   },
   "nyc": {

--- a/cloud/wfm-user/package.json
+++ b/cloud/wfm-user/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del coverage_report src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "npm run clean && nyc mocha"
   },
   "nyc": {

--- a/common/logger/package.json
+++ b/common/logger/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "npm run clean && nyc mocha",
     "example": "ts-node example/index.ts"
   },

--- a/demo/server/package.json
+++ b/demo/server/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "clean": "del coverage_report src/*.js src/**/*.js src/**/**/*.js src/*.map src/**/*.map src/**/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
+    "start": "node src/index.js",
+    "start:ts": "ts-node src/index.ts",
     "startDebug": "ts-node --inspect --debug-brk src/index.ts",
     "watch": "nodemon",
     "test": "nyc mocha"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cleanInstall": "lerna exec npm install --ignore-scripts",
     "bootstrap": "lerna bootstrap",
     "start": "lerna run start  --parallel --stream --scope=@raincatcher/demo-*",
+    "start:ts": "lerna run start:ts  --parallel --stream --scope=@raincatcher/demo-*",
     "docs": "./scripts/docgen.sh",
     "lint": "tslint '*/*/src/**/*.ts' '*/*/test/**/*.ts'",
     "build": "lerna run build",

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "clean": "del coverage_report src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "start": "ts-node src/index.ts",
     "test": "npm run clean && nyc mocha"
   },
   "nyc": {


### PR DESCRIPTION
## Motivation
`npm run start` should be the entry point for the compiled js runtime, running the typescript sources via ts-node should have a separate command.

## Description
Added new command to run the demo-server via typescript. Went with `npm run start:ts` since it matches the naming scheme used for the `clean:*` and `publish:*` commands.

## Progress
- [X] Remove extra npm start commands
- [X] Add new command for running via ts-node
- [X] Documentation
