### PR TITLE
Fix compilation error

### DIFF
--- a/cloud/wfm-rest-api/src/WfmRestApi.ts
+++ b/cloud/wfm-rest-api/src/WfmRestApi.ts
@@ -18,7 +18,7 @@ export class WfmRestApi {
   private workflowService: MongoDbRepository<WorkFlow>;
 
   constructor(userConfig?: Partial<ApiConfig>) {
-    this.config = _.defaults<ApiConfig>(defaultConfiguration, userConfig);
+    this.config = _.defaults(defaultConfiguration, userConfig);
     this.createWFMServices();
   }
 


### PR DESCRIPTION
## Description
Core fails to start due to the following typescript compilation error:
`Unable to compile TypeScript: ../../cloud/wfm-rest-api/src/WfmRestApi.ts (21,19): Expected at least 1 arguments, but got 2.`
