### PR TITLE
[RAINCATCH-1352] Integrate fileStore with Server

### DIFF
--- a/cloud/filestore/src/FileRoutes.ts
+++ b/cloud/filestore/src/FileRoutes.ts
@@ -1,6 +1,6 @@
 import { getLogger } from '@raincatcher/logger';
 import { Router } from 'express';
-import uuid from 'uuid-js';
+import uuid = require('uuid-js');
 import { FileStorage } from './file-api/FileStorage';
 import * as fileService from './services/FileService';
 

--- a/cloud/filestore/src/impl/S3Storage.ts
+++ b/cloud/filestore/src/impl/S3Storage.ts
@@ -121,4 +121,3 @@ export class LocalStorage implements FileStorage {
     }
   }
 }
-

--- a/demo/server/package.json
+++ b/demo/server/package.json
@@ -63,6 +63,7 @@
     "@raincatcher/auth-passport": "0.0.5",
     "@raincatcher/datasync-cloud": "0.0.5",
     "@raincatcher/express-auth": "0.0.5",
+    "@raincatcher/filestore": "1.0.0",
     "@raincatcher/logger": "0.0.1",
     "@raincatcher/wfm-demo-data": "0.0.5",
     "@raincatcher/wfm-rest-api": "0.0.5",

--- a/demo/server/src/modules/index.ts
+++ b/demo/server/src/modules/index.ts
@@ -1,6 +1,7 @@
 import { SyncExpressMiddleware, userMapperMiddleware } from '@raincatcher/datasync-cloud';
 import SyncServer, { SyncApi, SyncOptions } from '@raincatcher/datasync-cloud';
 import { EndpointSecurity } from '@raincatcher/express-auth';
+import { createRouter as createFileRouter, FileMetadata, FileStorage, GridFsStorage } from '@raincatcher/filestore';
 import { getLogger } from '@raincatcher/logger';
 import initData from '@raincatcher/wfm-demo-data';
 import { WfmRestApi } from '@raincatcher/wfm-rest-api';
@@ -30,6 +31,7 @@ export function setupModules(app: express.Express) {
   mobileSecurityMiddleware = securitySetup(mobileApp);
   const connectionPromise = syncSetup(mobileApp);
   demoDataSetup(connectionPromise);
+  fileStoreSetup(mobileApp, mobileSecurityMiddleware);
 
   const portalApp = express.Router();
   portalsecurityMiddleware = securitySetup(portalApp, globalSessionOptions);
@@ -92,6 +94,11 @@ function wfmApiSetup(app: express.Router, connectionPromise: Promise<any>) {
     // Fix compilation problem with different version of Db.
     api.setDb(mongo as any);
   });
+}
+
+function fileStoreSetup(app: express.Router, securityMiddleware: EndpointSecurity) {
+  const fileStore: FileStorage = new GridFsStorage(config.mongodb.url);
+  app.use('/file', createFileRouter(fileStore));
 }
 
 function demoDataSetup(connectionPromise: Promise<Db>) {


### PR DESCRIPTION
## Description
Integrate file storage module with the reference server application to provide the functionality by default.

## Progress
- [x] Integrate fileStore with the server app
- [ ] Expose module config options in server configuration

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1352
