### PR TITLE
fix file-store api

### DIFF
--- a/cloud/filestore/src/FileRoutes.ts
+++ b/cloud/filestore/src/FileRoutes.ts
@@ -11,8 +11,9 @@ import * as fileService from './services/FileService';
  * @returns router instance of express router
  */
 export function createRouter(storageEngine: FileStorage) {
+  fileService.createTemporaryStorageFolder();
   const router = Router();
-  router.route('/:filename').post(function(req, res, next) {
+  router.route('/base64/:filename').post(function(req, res, next) {
     const id = uuid.create().toString();
     const fileMeta = {
       owner: req.params.owner,
@@ -35,14 +36,10 @@ export function createRouter(storageEngine: FileStorage) {
   const binaryUploadInitMiddleware = function(req, res, next) {
     req.fileMeta = {};
     req.fileMeta.id = uuid.create().toString();
-    req.fileMeta.name = req.body.fileName;
-    req.fileMeta.namespace = req.body.namespace;
-    req.fileMeta.owner = req.body.ownerId;
-    req.fileMeta.mimetype = req.file.mimetype;
     next();
   };
 
-  router.route('/:filename/binary').post(binaryUploadInitMiddleware, fileService.mutlerMiddleware,
+  router.route('/binary/:filename').post(binaryUploadInitMiddleware, fileService.mutlerMiddleware(),
     function(req: any, res, next) {
       const fileMeta = req.fileMeta;
       const location = fileService.buildFilePath(fileMeta.id);
@@ -54,7 +51,7 @@ export function createRouter(storageEngine: FileStorage) {
       });
     });
 
-  router.route('/:filename').get(function(req, res) {
+  router.route('/binary/:filename').get(function(req, res) {
     const fileName = req.params.filename;
     const namespace = req.params.namespace;
     storageEngine.streamFile(namespace, fileName).then(function(buffer) {

--- a/cloud/filestore/src/services/FileService.ts
+++ b/cloud/filestore/src/services/FileService.ts
@@ -81,5 +81,5 @@ export function mutlerMiddleware() {
         cb(null, req.fileMeta.id);
       }
     })
-  }).single('binaryfile');
+  }).any();
 }

--- a/demo/server/src/modules/index.ts
+++ b/demo/server/src/modules/index.ts
@@ -98,7 +98,8 @@ function wfmApiSetup(app: express.Router, connectionPromise: Promise<any>) {
 
 function fileStoreSetup(app: express.Router, securityMiddleware: EndpointSecurity) {
   const fileStore: FileStorage = new GridFsStorage(config.mongodb.url);
-  app.use('/file', createFileRouter(fileStore));
+  const role = config.security.userRole;
+  app.use('/file', securityMiddleware.protect(role), createFileRouter(fileStore));
 }
 
 function demoDataSetup(connectionPromise: Promise<Db>) {


### PR DESCRIPTION
## Description
Fixed and added securityMiddleware to the filestore API\

NOTE: Endpoint for filestore has been changed to `/file/binary/` or `/file/base64/`