### PR TITLE
[RAINCATCH-1389] Support base64 upload

### DIFF
--- a/client/filestore-client/package.json
+++ b/client/filestore-client/package.json
@@ -47,6 +47,7 @@
     "typescript": "^2.3.4"
   },
   "dependencies": {
+    "b64-to-blob": "^1.2.19",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4"
   }

--- a/client/filestore-client/src/FileQueue.ts
+++ b/client/filestore-client/src/FileQueue.ts
@@ -54,7 +54,7 @@ export class FileQueue {
    */
   public addItem(item: FileQueueEntry) {
     this.queueData.push(item);
-    this.saveData();
+    return this.saveData();
   }
   /**
    * Remove item from queue.
@@ -62,7 +62,7 @@ export class FileQueue {
    */
   public removeItem(item: FileQueueEntry) {
     _.remove(this.queueData, item);
-    this.saveData();
+    return this.saveData();
   }
 
   /**

--- a/client/filestore-client/src/FileQueueEntry.ts
+++ b/client/filestore-client/src/FileQueueEntry.ts
@@ -6,5 +6,6 @@ export interface FileQueueEntry {
    * Uri to local filesystem containing file
    */
   uri: string;
+  type: 'uri'|'base64';
   id?: string;
 }

--- a/client/filestore-client/src/HttpClient.ts
+++ b/client/filestore-client/src/HttpClient.ts
@@ -1,3 +1,4 @@
+import * as Promise from 'bluebird';
 export interface HttpClient {
   upload: (url: string, data: FormData) => Promise<Response>;
   download: (url: string) => Promise<Response>;

--- a/cloud/filestore/src/FileRoutes.ts
+++ b/cloud/filestore/src/FileRoutes.ts
@@ -1,8 +1,14 @@
 import { getLogger } from '@raincatcher/logger';
 import { Router } from 'express';
+import { Request } from 'express';
 import * as uuid from 'uuid-js';
+import { FileMetadata } from './file-api/FileMetadata';
 import { FileStorage } from './file-api/FileStorage';
 import * as fileService from './services/FileService';
+
+interface FileMetadataRequest extends Request {
+  fileMeta: FileMetadata;
+}
 
 /**
  * Create express based router router for fileService
@@ -11,17 +17,18 @@ import * as fileService from './services/FileService';
  * @returns router instance of express router
  */
 export function createRouter(storageEngine: FileStorage) {
+
+  const generateIdMiddleware = function(req, res, next) {
+    req.fileMeta = {};
+    req.fileMeta.id = uuid.create().toString();
+    next();
+  };
+
   fileService.createTemporaryStorageFolder();
   const router = Router();
-  router.route('/base64/:filename').post(function(req, res, next) {
-    const id = uuid.create().toString();
-    const fileMeta = {
-      owner: req.params.owner,
-      name: req.params.filename,
-      namespace: req.params.namespace,
-      id
-    };
+  router.route('/base64').post(generateIdMiddleware, function(req: FileMetadataRequest, res, next) {
     const stream = fileService.parseBase64Stream(req);
+    const fileMeta: FileMetadata = req.fileMeta;
     fileService.writeStreamToFile(fileMeta, stream).then(function() {
       const location = fileService.buildFilePath(fileMeta.id);
       return storageEngine.writeFile(fileMeta, location);
@@ -33,14 +40,8 @@ export function createRouter(storageEngine: FileStorage) {
     });
   });
 
-  const binaryUploadInitMiddleware = function(req, res, next) {
-    req.fileMeta = {};
-    req.fileMeta.id = uuid.create().toString();
-    next();
-  };
-
-  router.route('/binary').post(binaryUploadInitMiddleware, fileService.mutlerMiddleware(),
-    function(req: any, res, next) {
+  router.route('/binary').post(generateIdMiddleware, fileService.multerMiddleware(),
+    function(req: FileMetadataRequest, res, next) {
       const fileMeta = req.fileMeta;
       const location = fileService.buildFilePath(fileMeta.id);
       storageEngine.writeFile(fileMeta, location).then(function() {

--- a/cloud/filestore/src/FileRoutes.ts
+++ b/cloud/filestore/src/FileRoutes.ts
@@ -26,21 +26,7 @@ export function createRouter(storageEngine: FileStorage) {
 
   fileService.createTemporaryStorageFolder();
   const router = Router();
-  router.route('/base64').post(generateIdMiddleware, function(req: FileMetadataRequest, res, next) {
-    const stream = fileService.parseBase64Stream(req);
-    const fileMeta: FileMetadata = req.fileMeta;
-    fileService.writeStreamToFile(fileMeta, stream).then(function() {
-      const location = fileService.buildFilePath(fileMeta.id);
-      return storageEngine.writeFile(fileMeta, location);
-    }).then(function() {
-      res.json(fileMeta);
-    }).catch(function(err) {
-      getLogger().error(err);
-      next(err);
-    });
-  });
-
-  router.route('/binary').post(generateIdMiddleware, fileService.multerMiddleware(),
+  router.route('/').post(generateIdMiddleware, fileService.multerMiddleware(),
     function(req: FileMetadataRequest, res, next) {
       const fileMeta = req.fileMeta;
       const location = fileService.buildFilePath(fileMeta.id);
@@ -52,8 +38,8 @@ export function createRouter(storageEngine: FileStorage) {
       });
     });
 
-  router.route('/binary/:filename').get(function(req, res) {
-    const fileName = req.params.filename;
+  router.route('/:id').get(function(req, res) {
+    const fileName = req.params.id;
     const namespace = req.params.namespace;
     storageEngine.streamFile(namespace, fileName).then(function(buffer) {
       if (buffer) {

--- a/cloud/filestore/src/services/FileService.ts
+++ b/cloud/filestore/src/services/FileService.ts
@@ -1,11 +1,14 @@
 import { getLogger } from '@raincatcher/logger';
 import * as base64 from 'base64-stream';
+import { Request } from 'express';
 import * as fs from 'fs';
 import multer = require('multer');
 import * as  os from 'os';
 import * as path from 'path';
 import q from 'q';
+import { Stream } from 'stream';
 import through from 'through2';
+import { FileMetadata } from '../file-api/FileMetadata';
 
 const imageDir = os.tmpdir() + '/raincatcher-file-store';
 
@@ -27,7 +30,7 @@ export function createTemporaryStorageFolder() {
  * @param fileMeta
  * @param stream
  */
-export function writeStreamToFile(fileMeta, stream) {
+export function writeStreamToFile(fileMeta: FileMetadata, stream: Stream) {
   const deferred = q.defer();
   stream.on('end', function() {
     deferred.resolve(fileMeta);
@@ -35,7 +38,7 @@ export function writeStreamToFile(fileMeta, stream) {
   stream.on('error', function(error) {
     deferred.reject(error);
   });
-  const filename = imageDir + '/' + fileMeta.uid;
+  const filename = imageDir + '/' + fileMeta.id;
   stream.pipe(fs.createWriteStream(filename));
   return deferred.promise;
 }
@@ -45,7 +48,7 @@ export function writeStreamToFile(fileMeta, stream) {
  *
  * @param req
  */
-export function parseBase64Stream(req) {
+export function parseBase64Stream(req: Request) {
   let passthrough = false;
   let accumulation = '';
   const stream = req.pipe(through(function(chunk, enc, callback) {
@@ -71,7 +74,7 @@ export function buildFilePath(fileName) {
   return path.join(imageDir, fileName);
 }
 
-export function mutlerMiddleware() {
+export function multerMiddleware() {
   return multer({
     storage: multer.diskStorage({
       destination(req, file, cb) {


### PR DESCRIPTION
## Motivation
Add support for running the gallery step in a browser by being able to upload the base64-encoded images.

## Description

- [X] Convert base64 data to Blob
- [X] Support upload of base64-converted binary data
- [x] Remove unused `base64/` endpoints