### PR TITLE
[RAINCATCH-1386] Add unit tests for FileStore Client

### DIFF
--- a/client/filestore-client/package.json
+++ b/client/filestore-client/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "del coverage_report src/**/*.js src/**/*.map test/**/*.js test/**/*.map",
     "build": "tsc",
-    "test": "npm run clean && nyc mocha"
+    "test": "nyc mocha"
   },
   "publishConfig": {
     "access": "public"
@@ -35,16 +35,22 @@
     "branches": 80
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.8",
+    "@types/bluebird": "^3.5.16",
+    "@types/chai": "^4.0.4",
+    "@types/chai-as-promised": "^7.1.0",
     "@types/cordova-plugin-file": "0.0.3",
     "@types/cordova-plugin-file-transfer": "0.0.3",
     "@types/lodash": "^4.14.73",
     "@types/mocha": "^2.2.41",
     "@types/proxyquire": "^1.3.27",
+    "@types/sinon": "^2.3.7",
+    "chai": "^4.1.2",
+    "chai-as-promised": "^7.1.1",
     "del-cli": "^1.0.0",
     "mocha": "^4.0.1",
     "nyc": "^11.1.0",
     "proxyquire": "^1.8.0",
+    "sinon": "^4.1.1",
     "source-map-support": "^0.5.0",
     "ts-node": "^3.3.0",
     "typescript": "^2.5.0"

--- a/client/filestore-client/src/FileManager.ts
+++ b/client/filestore-client/src/FileManager.ts
@@ -121,6 +121,9 @@ export class FileManager {
     return this.fileSupport.uploadFile(file).then(function(createdFile) {
       self.uploadQueue.removeItem(file);
       console.info('File saved', createdFile);
+    }).catch(function(err) {
+      // Adds file to the upload queue
+      self.uploadQueue.addItem(file);
     });
   }
 }

--- a/client/filestore-client/src/FileQueue.ts
+++ b/client/filestore-client/src/FileQueue.ts
@@ -12,9 +12,9 @@ export class FileQueue {
     this.queueName = name;
   }
 
-   /**
-    * Save queue items to local storage.
-    */
+  /**
+   * Save queue items to localStorage
+   */
   public saveData() {
     const toSave = JSON.stringify({
       queue: this.queueData
@@ -24,7 +24,7 @@ export class FileQueue {
   }
 
   /**
-   * Read queue items from local storage.
+   * Restore the local queueData to reflect the data of the queue in localStorage.
    */
   public restoreData() {
     const queueDataString = this.localStorage.getItem(this.queueName);
@@ -38,14 +38,14 @@ export class FileQueue {
   }
 
   /**
-   * Get queue items
+   * Get the local queue items
    */
   public getItemList(): FileQueueEntry[] {
     return this.queueData;
   }
 
   /**
-   * Add new item to the queue
+   * Add a new item to the queue
    * @param item - Contains information required to upload files to the server.
    * @see FileQueueEntry
    */

--- a/client/filestore-client/src/FileQueueEntry.ts
+++ b/client/filestore-client/src/FileQueueEntry.ts
@@ -15,5 +15,5 @@ export interface FileQueueEntry {
   /**
    * File identifier
    */
-  id?: string;
+  id: string;
 }

--- a/client/filestore-client/test/FileManagerTest.ts
+++ b/client/filestore-client/test/FileManagerTest.ts
@@ -1,0 +1,90 @@
+import * as  chai from 'chai';
+import * as chaiAsPromise from 'chai-as-promised';
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+import { FileQueue } from '../src/FileQueue';
+import { FileQueueEntry } from '../src/FileQueueEntry';
+
+declare var global: NodeJS.Global | any;
+
+const { expect } = chai;
+
+describe('File Manager Tests', function() {
+  const mockServerUrl = 'mockServerUrl';
+  const mockFileQueueName = 'mockQueueName';
+  const mockHttpClient = {
+    upload: sinon.stub(),
+    download: sinon.stub()
+  };
+  const mockLocalStorage = {
+    setItem: sinon.stub(),
+    getItem: sinon.stub().returns('{}')
+  };
+
+  const mockFileOnline: FileQueueEntry = {
+    uri: 'mockURIOnline',
+    type: 'uri',
+    id: 'mockFileIdOnline'
+  };
+
+  const mockFileOffline: FileQueueEntry = {
+    uri: 'mockURIOffline',
+    type: 'uri',
+    id: 'mockFileIdOffline'
+  };
+
+  const fileCreatedMessage = 'mockFileCreated';
+  const fileNotCreatedMessage = 'mockFileNotCreated';
+
+  const mockUploadFile = function() {
+    const stub = sinon.stub();
+    stub.withArgs(mockFileOnline).resolves(fileCreatedMessage);
+    stub.withArgs(mockFileOffline).rejects(fileNotCreatedMessage);
+    stub.rejects('offline');
+    return stub;
+  };
+
+  const CordovaFileSupport = function(serverUrl, HttpInterface) {
+    return {
+      downloadFileFromServer: sinon.stub(),
+      uploadFile: mockUploadFile()
+    };
+  };
+
+  let testSubject;
+
+  // Mock DOM objects used by FileManager
+  global.document = {
+    addEventListener: sinon.stub()
+  };
+  global.window = {
+    localStorage: mockLocalStorage
+  };
+
+  const FileManager = proxyquire.load('../src/FileManager', {
+    './CordovaFileSupport': {
+      'CordovaFileSupport': CordovaFileSupport
+    }
+  }).FileManager;
+
+  beforeEach(function() {
+    testSubject = new FileManager(mockServerUrl, mockFileQueueName, mockHttpClient);
+  });
+
+  it('should upload a file when the device is online', function(done) {
+    testSubject.scheduleFileToBeUploaded(mockFileOnline).then(function(result) {
+      expect(result).to.equal(fileCreatedMessage);
+      done();
+    });
+  });
+
+  it('should not upload a file when the device is offline', function(done) {
+    testSubject.scheduleFileToBeUploaded(mockFileOffline).then(function(result) {
+      console.log('result', result);
+      done();
+    }).catch(function(err) {
+      console.log('err', err);
+      done();
+    });
+  });
+});

--- a/client/filestore-client/test/FileQueueTest.ts
+++ b/client/filestore-client/test/FileQueueTest.ts
@@ -1,0 +1,72 @@
+import * as  chai from 'chai';
+import * as sinon from 'sinon';
+import { FileQueue } from '../src/FileQueue';
+import { FileQueueEntry } from '../src/FileQueueEntry';
+
+const { expect } = chai;
+
+describe('File Queue Tests', function() {
+  const mockQueue = '{"queue": [{"uri": "mockURI", "type": "uri", "id": "mockID"}]}';
+  const queueName = 'testFileQueue';
+  const mockFileQueueEntry: FileQueueEntry = {
+    uri: 'mockURI',
+    type: 'uri',
+    id: 'mockID'
+  };
+  let testSubject;
+  let mockLocalStorage;
+
+  beforeEach(function() {
+    mockLocalStorage = {
+      getItem: sinon.stub().returns(mockQueue),
+      setItem: sinon.stub()
+    };
+    testSubject = new FileQueue(mockLocalStorage, queueName);
+  });
+
+  it('should be able to add an item to the queue', function() {
+    const expectedQueueList: FileQueueEntry[] = [];
+    expectedQueueList.push(mockFileQueueEntry);
+    testSubject.addItem(mockFileQueueEntry);
+
+    expect(testSubject.getItemList()).to.deep.equal(expectedQueueList);
+    sinon.assert.calledOnce(mockLocalStorage.setItem);
+    sinon.assert.calledWith(mockLocalStorage.setItem, queueName, JSON.stringify({queue: expectedQueueList}));
+  });
+
+  it('should be able to remove an item from the queue', function() {
+    testSubject.addItem(mockFileQueueEntry);
+    const expectedQueueList: FileQueueEntry[] = [];
+    testSubject.removeItem(mockFileQueueEntry);
+
+    expect(testSubject.getItemList()).to.deep.equal(expectedQueueList);
+    sinon.assert.calledWith(mockLocalStorage.setItem, queueName, JSON.stringify({queue: expectedQueueList}));
+  });
+
+  it('should be able to read an item from the queue', function() {
+    testSubject.addItem(mockFileQueueEntry);
+
+    expect(testSubject.readItem(mockFileQueueEntry.id)).to.deep.equal(mockFileQueueEntry);
+  });
+
+  it('should restore the local queue data to reflect the queue in local storage', function() {
+    const expectedQueueList: FileQueueEntry[] = [];
+    expectedQueueList.push(mockFileQueueEntry);
+
+    expect(testSubject.restoreData().getItemList()).to.deep.equal(expectedQueueList);
+    sinon.assert.calledOnce(mockLocalStorage.getItem);
+    sinon.assert.calledWith(mockLocalStorage.getItem, queueName);
+  });
+
+  it('should restore the queue data to an empty array if the queue in the local storage is empty', function() {
+    mockLocalStorage = {
+      getItem: sinon.stub().returns(undefined),
+      setItem: sinon.stub()
+    };
+    testSubject = new FileQueue(mockLocalStorage, queueName);
+
+    expect(testSubject.restoreData().getItemList()).to.deep.equal([]);
+    sinon.assert.calledOnce(mockLocalStorage.getItem);
+    sinon.assert.calledWith(mockLocalStorage.getItem, queueName);
+  });
+});


### PR DESCRIPTION
## Description
Add unit tests for filestore-client

## Progress
- [x] Add unit tests for FileQueue
- [ ] Add unit tests for CordovaFileSupport
- [x] Add unit tests for FileManager

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/RAINCATCH-1386