### PR TITLE
Add specific libs to the tsc compiler to fix compilation issues in angularjs

### DIFF
--- a/client/camera/tsconfig.json
+++ b/client/camera/tsconfig.json
@@ -5,7 +5,12 @@
         "noImplicitAny": false,
         "experimentalDecorators": true,
         "strictNullChecks": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "lib": [
+            "dom.iterable",
+            "es6",
+            "dom"
+        ]
     },
     "include": [
         "src/",

--- a/client/filestore-client/package.json
+++ b/client/filestore-client/package.json
@@ -41,6 +41,7 @@
     "@types/cordova-plugin-file-transfer": "0.0.3",
     "@types/lodash": "^4.14.73",
     "@types/mocha": "^2.2.41",
+    "@types/node": "^8.0.7",
     "@types/proxyquire": "^1.3.27",
     "@types/sinon": "^4.0.0",
     "chai": "^4.1.1",

--- a/client/filestore-client/tsconfig.json
+++ b/client/filestore-client/tsconfig.json
@@ -5,7 +5,12 @@
         "noImplicitAny": false,
         "experimentalDecorators": true,
         "strictNullChecks": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "lib": [
+            "dom",
+            "es6",
+            "scripthost"
+        ]
     },
     "include": [
         "src/",


### PR DESCRIPTION
## Motivation
Fix compilation issues for camera and filestore-client on angularjs repo CI

## Description
Add extra libs from the typescript compiler to assure compilation runs okay.

Tested locally with a fresh checkout from angularjs and using `raincatcher-angularjs/scripts/checkoutCore clone -b fix-angularjs-compilation && npm run bootstrapCI && npm run testCI`, so it should turn angularjs' travis build green.