### PR TITLE
[RAINCATCH 1399] docs fix

### DIFF
--- a/client/camera/src/Camera.ts
+++ b/client/camera/src/Camera.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/camera
+ */
+
 'use strict';
 
 import * as Promise from 'bluebird';

--- a/client/camera/src/buildCameraOptions.ts
+++ b/client/camera/src/buildCameraOptions.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/camera
+ */
+
+/**
  * Default options for the cordova camera plugin
  * @param cordovaCamera Apache Cordova's Camera object
  */

--- a/client/camera/src/index.ts
+++ b/client/camera/src/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @module @raincatcher/camera
+ */
+
 export * from './Camera';

--- a/client/datasync-client/src/DataManager.ts
+++ b/client/datasync-client/src/DataManager.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-client
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as Bluebird from 'bluebird';
 import * as syncApi from 'fh-sync-js';

--- a/client/datasync-client/src/index.ts
+++ b/client/datasync-client/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-client
+ */
+
 import * as sync from 'fh-sync-js';
 
 // Support named import

--- a/client/filestore-client/src/CordovaFileSupport.ts
+++ b/client/filestore-client/src/CordovaFileSupport.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore-client
+ */
+
 import b64ToBlob from 'b64-to-blob';
 import * as Bluebird from 'bluebird';
 import { each } from 'lodash';

--- a/client/filestore-client/src/FileManager.ts
+++ b/client/filestore-client/src/FileManager.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore-client
+ */
+
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';
 import { CordovaFileSupport } from './CordovaFileSupport';

--- a/client/filestore-client/src/FileQueue.ts
+++ b/client/filestore-client/src/FileQueue.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore-client
+ */
+
 import * as _ from 'lodash';
 import { FileQueueEntry } from './FileQueueEntry';
 

--- a/client/filestore-client/src/FileQueueEntry.ts
+++ b/client/filestore-client/src/FileQueueEntry.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/filestore-client
+ */
+
+/**
  * Contains fields required for uploading and downloading a file.
  */
 export interface FileQueueEntry {

--- a/client/filestore-client/src/HttpClient.ts
+++ b/client/filestore-client/src/HttpClient.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore-client
+ */
+
 import * as Promise from 'bluebird';
 
 /**

--- a/client/filestore-client/src/index.ts
+++ b/client/filestore-client/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore-client
+ */
+
 export * from './FileManager';
 export * from './FileQueueEntry';
 export * from './HttpClient';

--- a/client/wfm/src/index.ts
+++ b/client/wfm/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm
+ */
+
 export { WorkOrder } from './model/WorkOrder';
 export { WorkFlow } from './model/WorkFlow';
 export { StepResult } from './model/StepResult';

--- a/client/wfm/src/model/Step.ts
+++ b/client/wfm/src/model/Step.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/wfm
+ */
+
+/**
  * A single unit of work, containing its identifier and runtime options for customizing behavior.
  */
 export interface Step {

--- a/client/wfm/src/model/StepResult.ts
+++ b/client/wfm/src/model/StepResult.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm
+ */
+
 import { STATUS } from '../status';
 import { Step } from './Step';
 

--- a/client/wfm/src/model/WorkFlow.ts
+++ b/client/wfm/src/model/WorkFlow.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm
+ */
+
 import { Step } from '../model/Step';
 import { WorkOrder } from '../model/WorkOrder';
 

--- a/client/wfm/src/model/WorkOrder.ts
+++ b/client/wfm/src/model/WorkOrder.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm
+ */
+
 import * as Promise from 'bluebird';
 import { min } from 'lodash';
 import { STATUS } from '../status';

--- a/client/wfm/src/service/DataService.ts
+++ b/client/wfm/src/service/DataService.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm
+ */
+
 import * as Promise from 'bluebird';
 /**
  * Deifinition for data acess service used by the {@link WfmService}

--- a/client/wfm/src/service/UserService.ts
+++ b/client/wfm/src/service/UserService.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm
+ */
+
 import * as Promise from 'bluebird';
 export interface UserService {
   readUser(): Promise<{id: string}>;

--- a/client/wfm/src/service/WfmService.ts
+++ b/client/wfm/src/service/WfmService.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm
+ */
+
 import * as Promise from 'bluebird';
 import * as _ from 'lodash';
 import * as shortid from 'shortid';

--- a/client/wfm/src/status.ts
+++ b/client/wfm/src/status.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/wfm
+ */
+
+/**
  * List of available status for {@link WorkOrder}s and their individual {@link Step}s
  */
 export enum STATUS {

--- a/cloud/auth/src/EndpointSecurity.ts
+++ b/cloud/auth/src/EndpointSecurity.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/express-auth
+ */
+
 import * as express from 'express';
 import { SessionOptions } from 'express-session';
 

--- a/cloud/auth/src/index.ts
+++ b/cloud/auth/src/index.ts
@@ -1,1 +1,5 @@
+/**
+ * @module @raincatcher/express-auth
+ */
+
 export * from './EndpointSecurity';

--- a/cloud/datasync/src/SyncApi.ts
+++ b/cloud/datasync/src/SyncApi.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-cloud
+ */
+
 import { Db } from 'mongodb';
 import SyncDatasetOptions from './options/SyncDatasetOptions';
 import SyncOptions from './options/SyncGlobalOptions';

--- a/cloud/datasync/src/SyncServer.ts
+++ b/cloud/datasync/src/SyncServer.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-cloud
+ */
+
 import * as sync from 'fh-sync';
 import { Db } from 'mongodb';
 import SyncDataSetOptions from './options/SyncDatasetOptions';

--- a/cloud/datasync/src/index.ts
+++ b/cloud/datasync/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-cloud
+ */
+
 import * as sync from 'fh-sync';
 import SyncServer from './SyncServer';
 

--- a/cloud/datasync/src/options/SyncDatasetOptions.ts
+++ b/cloud/datasync/src/options/SyncDatasetOptions.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/datasync-cloud
  */
 
-
 import { CollisionHandler, HashFunction } from './SyncGlobalOptions';
 /**
  * Options used to initialize single dataset

--- a/cloud/datasync/src/options/SyncDatasetOptions.ts
+++ b/cloud/datasync/src/options/SyncDatasetOptions.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-cloud
+ */
+
 
 import { CollisionHandler, HashFunction } from './SyncGlobalOptions';
 /**

--- a/cloud/datasync/src/options/SyncGlobalOptions.ts
+++ b/cloud/datasync/src/options/SyncGlobalOptions.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-cloud
+ */
+
 import * as sync from 'fh-sync';
 
 /**

--- a/cloud/datasync/src/web/SyncMapperMiddleware.ts
+++ b/cloud/datasync/src/web/SyncMapperMiddleware.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-cloud
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as express from 'express';
 import * as sync from 'fh-sync';

--- a/cloud/datasync/src/web/SyncWebExpress.ts
+++ b/cloud/datasync/src/web/SyncWebExpress.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/datasync-cloud
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as Express from 'express';
 import * as sync from 'fh-sync';

--- a/cloud/filestore/src/FileRoutes.ts
+++ b/cloud/filestore/src/FileRoutes.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import { promisify } from 'bluebird';
 import { Router } from 'express';

--- a/cloud/filestore/src/file-api/FileMetadata.ts
+++ b/cloud/filestore/src/file-api/FileMetadata.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/filestore
+ */
+
+/**
  * Interface contains documented fields that can be used by implementation to save and query files.
  * Actual implementation can use any other fields that are required to be saved along with the file.
  */

--- a/cloud/filestore/src/file-api/FileStorage.ts
+++ b/cloud/filestore/src/file-api/FileStorage.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore
+ */
+
 import * as Promise from 'bluebird';
 import { Stream } from 'stream';
 import { FileMetadata } from './FileMetadata';

--- a/cloud/filestore/src/impl/GridFsStorage.ts
+++ b/cloud/filestore/src/impl/GridFsStorage.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as Promise from 'bluebird';
 import * as fs from 'fs';

--- a/cloud/filestore/src/impl/LocalStorage.ts
+++ b/cloud/filestore/src/impl/LocalStorage.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as BlueBird from 'bluebird';
 import { createReadStream } from 'fs';

--- a/cloud/filestore/src/impl/S3Storage.ts
+++ b/cloud/filestore/src/impl/S3Storage.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore
+ */
+
 
 import { getLogger } from '@raincatcher/logger';
 import * as Promise from 'bluebird';

--- a/cloud/filestore/src/impl/S3Storage.ts
+++ b/cloud/filestore/src/impl/S3Storage.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/filestore
  */
 
-
 import { getLogger } from '@raincatcher/logger';
 import * as Promise from 'bluebird';
 import * as mongo from 'mongodb';

--- a/cloud/filestore/src/index.ts
+++ b/cloud/filestore/src/index.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/filestore
  */
 
-
 export * from './FileRoutes';
 
 export * from './file-api/FileStorage';

--- a/cloud/filestore/src/index.ts
+++ b/cloud/filestore/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore
+ */
+
 
 export * from './FileRoutes';
 

--- a/cloud/filestore/src/services/FileService.ts
+++ b/cloud/filestore/src/services/FileService.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/filestore
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as base64 from 'base64-stream';
 import * as Promise from 'bluebird';

--- a/cloud/passportauth/src/auth/DefaultStrategies.ts
+++ b/cloud/passportauth/src/auth/DefaultStrategies.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/auth-passport
+ */
+
 
 import { UserRepository } from '../user/UserRepository';
 import { UserService } from '../user/UserService';

--- a/cloud/passportauth/src/auth/DefaultStrategies.ts
+++ b/cloud/passportauth/src/auth/DefaultStrategies.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/auth-passport
  */
 
-
 import { UserRepository } from '../user/UserRepository';
 import { UserService } from '../user/UserService';
 

--- a/cloud/passportauth/src/auth/PassportAuth.ts
+++ b/cloud/passportauth/src/auth/PassportAuth.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/auth-passport
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as express from 'express';
 import * as session from 'express-session';

--- a/cloud/passportauth/src/auth/UserSerializer.ts
+++ b/cloud/passportauth/src/auth/UserSerializer.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/auth-passport
+ */
+
+/**
  * Default serialize user function to be used by Passport. Stores the user to the session
  *
  * @param user - A user data to be stored in the session

--- a/cloud/passportauth/src/index.ts
+++ b/cloud/passportauth/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/auth-passport
+ */
+
 import * as passport from 'passport';
 
 export * from './user/UserService';

--- a/cloud/passportauth/src/user/UserRepository.ts
+++ b/cloud/passportauth/src/user/UserRepository.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/auth-passport
+ */
+
+/**
  * User repository interface for retrieving user related data.
  * Implementations can retrieve users from different databases etc.
  */

--- a/cloud/passportauth/src/user/UserService.ts
+++ b/cloud/passportauth/src/user/UserService.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/auth-passport
  */
 
-
 /**
  * User service interface that defines a set of requirements (methods) for mapping particular fields from the
  * user object returned from the repository.

--- a/cloud/passportauth/src/user/UserService.ts
+++ b/cloud/passportauth/src/user/UserService.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/auth-passport
+ */
+
 
 /**
  * User service interface that defines a set of requirements (methods) for mapping particular fields from the

--- a/cloud/wfm-demo-data/src/Workflows.ts
+++ b/cloud/wfm-demo-data/src/Workflows.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-demo-data
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import { WorkFlow } from '@raincatcher/wfm';
 import * as Promise from 'bluebird';

--- a/cloud/wfm-demo-data/src/Workorders.ts
+++ b/cloud/wfm-demo-data/src/Workorders.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-demo-data
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import { WorkOrder } from '@raincatcher/wfm';
 import * as Promise from 'bluebird';

--- a/cloud/wfm-demo-data/src/index.ts
+++ b/cloud/wfm-demo-data/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-demo-data
+ */
+
 import { Db } from 'mongodb';
 import workflowSetup from './Workflows';
 import workorderSetup from './Workorders';

--- a/cloud/wfm-rest-api/src/ApiConfig.ts
+++ b/cloud/wfm-rest-api/src/ApiConfig.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/wfm-rest-api
  */
 
-
 /**
  * Module configuration interface
  * Holds all values that can be changed to modify module behavior

--- a/cloud/wfm-rest-api/src/ApiConfig.ts
+++ b/cloud/wfm-rest-api/src/ApiConfig.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 
 /**
  * Module configuration interface

--- a/cloud/wfm-rest-api/src/WfmRestApi.ts
+++ b/cloud/wfm-rest-api/src/WfmRestApi.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 
 import { getLogger } from '@raincatcher/logger';
 import { WorkFlow, WorkOrder } from '@raincatcher/wfm';

--- a/cloud/wfm-rest-api/src/WfmRestApi.ts
+++ b/cloud/wfm-rest-api/src/WfmRestApi.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/wfm-rest-api
  */
 
-
 import { getLogger } from '@raincatcher/logger';
 import { WorkFlow, WorkOrder } from '@raincatcher/wfm';
 import * as Promise from 'bluebird';

--- a/cloud/wfm-rest-api/src/data-api/ApiError.ts
+++ b/cloud/wfm-rest-api/src/data-api/ApiError.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/wfm-rest-api
  */
 
-
 /**
  * Interface used to construct standardized response for api error handlers.
  */

--- a/cloud/wfm-rest-api/src/data-api/ApiError.ts
+++ b/cloud/wfm-rest-api/src/data-api/ApiError.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 
 /**
  * Interface used to construct standardized response for api error handlers.

--- a/cloud/wfm-rest-api/src/data-api/MongoPaginationEngine.ts
+++ b/cloud/wfm-rest-api/src/data-api/MongoPaginationEngine.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/wfm-rest-api
  */
 
-
 import * as Promise from 'bluebird';
 import { Cursor } from 'mongodb';
 import { DIRECTION, SortedPageRequest } from '../data-api/PageRequest';

--- a/cloud/wfm-rest-api/src/data-api/MongoPaginationEngine.ts
+++ b/cloud/wfm-rest-api/src/data-api/MongoPaginationEngine.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 
 import * as Promise from 'bluebird';
 import { Cursor } from 'mongodb';

--- a/cloud/wfm-rest-api/src/data-api/PageRequest.ts
+++ b/cloud/wfm-rest-api/src/data-api/PageRequest.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/wfm-rest-api
+ */
+
+/**
  *  Interface for pagination information.
  *  Represents page request (passed from client)
  *

--- a/cloud/wfm-rest-api/src/data-api/PageResponse.ts
+++ b/cloud/wfm-rest-api/src/data-api/PageResponse.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/wfm-rest-api
+ */
+
+/**
  * Wrapper interface to return ordered and pagged list of items.
  */
 export interface PageResponse<T> {

--- a/cloud/wfm-rest-api/src/data-api/PagingDataRepository.ts
+++ b/cloud/wfm-rest-api/src/data-api/PagingDataRepository.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 import * as Promise from 'bluebird';
 import { Db } from 'mongodb';
 import { SortedPageRequest } from '../data-api/PageRequest';

--- a/cloud/wfm-rest-api/src/impl/ApiController.ts
+++ b/cloud/wfm-rest-api/src/impl/ApiController.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import * as Bluebird from 'bluebird';
 import * as express from 'express';

--- a/cloud/wfm-rest-api/src/impl/ErrorCodes.ts
+++ b/cloud/wfm-rest-api/src/impl/ErrorCodes.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 
 export const CLIENT_ERROR = 'CLIENT_ARGUMENT_ERROR';
 export const MISSING_ID = 'MISSING_ID';

--- a/cloud/wfm-rest-api/src/impl/ErrorCodes.ts
+++ b/cloud/wfm-rest-api/src/impl/ErrorCodes.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/wfm-rest-api
  */
 
-
 export const CLIENT_ERROR = 'CLIENT_ARGUMENT_ERROR';
 export const MISSING_ID = 'MISSING_ID';
 export const DB_ERROR = 'DB_ERROR';

--- a/cloud/wfm-rest-api/src/impl/MongoDbRepository.ts
+++ b/cloud/wfm-rest-api/src/impl/MongoDbRepository.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 import * as Bluebird from 'bluebird';
 import { Collection, Cursor, CursorCommentOptions, Db } from 'mongodb';
 import { ObjectID } from 'mongodb';

--- a/cloud/wfm-rest-api/src/index.ts
+++ b/cloud/wfm-rest-api/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-rest-api
+ */
+
 // WFM implementation
 export * from './WfmRestApi';
 

--- a/cloud/wfm-user/src/datasources/User.ts
+++ b/cloud/wfm-user/src/datasources/User.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/wfm-user
+ */
+
+/**
  * User interface that defines requred fields for WFM integration.
  * Fields are used in portal application
  */

--- a/cloud/wfm-user/src/datasources/UserController.ts
+++ b/cloud/wfm-user/src/datasources/UserController.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-user
+ */
+
 import { getLogger } from '@raincatcher/logger';
 import { ApiError } from '@raincatcher/wfm-rest-api';
 import * as Bluebird from 'bluebird';

--- a/cloud/wfm-user/src/datasources/UsersRepository.ts
+++ b/cloud/wfm-user/src/datasources/UsersRepository.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/wfm-user
  */
 
-
 import * as Bluebird from 'bluebird';
 import { User } from './User';
 

--- a/cloud/wfm-user/src/datasources/UsersRepository.ts
+++ b/cloud/wfm-user/src/datasources/UsersRepository.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-user
+ */
+
 
 import * as Bluebird from 'bluebird';
 import { User } from './User';

--- a/cloud/wfm-user/src/index.ts
+++ b/cloud/wfm-user/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/wfm-user
+ */
+
 export * from './datasources/User';
 export * from './datasources/UserController';
 export * from './datasources/UsersRepository';

--- a/common/logger/src/BunyanLogger.ts
+++ b/common/logger/src/BunyanLogger.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/logger
+ */
+
 import * as bunyan from 'bunyan';
 import Logger from './Logger';
 

--- a/common/logger/src/ClientLogger.ts
+++ b/common/logger/src/ClientLogger.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/logger
+ */
+
 import { Logger } from './Logger';
 // tslint:disable-next-line:no-var-requires
 const logger: any = require('loglevel');

--- a/common/logger/src/Logger.ts
+++ b/common/logger/src/Logger.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/logger
+ */
+
+/**
  * Logging interface used in all RainCatcher modules
  * Clients can extend it to integrate with their own logging library.
  * Interface may be used on both server and client environments

--- a/common/logger/src/index.ts
+++ b/common/logger/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/logger
+ */
+
 import { BunyanLogger } from './BunyanLogger';
 import { ClientLogger } from './ClientLogger';
 import { EmptyLogger, Logger } from './Logger';

--- a/demo/server/src/app.ts
+++ b/demo/server/src/app.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 'use strict';
 
 import { getLogger } from '@raincatcher/logger';

--- a/demo/server/src/index.ts
+++ b/demo/server/src/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 'use strict';
 /**
  * Module dependencies.

--- a/demo/server/src/modules/datasync/Connector.ts
+++ b/demo/server/src/modules/datasync/Connector.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import SyncServer, { SyncApi, SyncExpressMiddleware, SyncOptions } from '@raincatcher/datasync-cloud';
 import { getLogger } from '@raincatcher/logger';
 import * as Promise from 'bluebird';

--- a/demo/server/src/modules/datasync/MongoDataHandler.ts
+++ b/demo/server/src/modules/datasync/MongoDataHandler.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import { sync } from '@raincatcher/datasync-cloud';
 import { Db } from 'mongodb';
 

--- a/demo/server/src/modules/datasync/filters/ExcludeCompletedWorkorders.ts
+++ b/demo/server/src/modules/datasync/filters/ExcludeCompletedWorkorders.ts
@@ -1,4 +1,8 @@
 /**
+ * @module @raincatcher/demo-server
+ */
+
+/**
  * Excludes WorkOrders with a Complete date over a set number of days ago
  * @param queryParams
  */

--- a/demo/server/src/modules/index.ts
+++ b/demo/server/src/modules/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import { SyncExpressMiddleware, userMapperMiddleware } from '@raincatcher/datasync-cloud';
 import SyncServer, { SyncApi, SyncOptions } from '@raincatcher/datasync-cloud';
 import { EndpointSecurity } from '@raincatcher/express-auth';

--- a/demo/server/src/modules/keycloak/index.ts
+++ b/demo/server/src/modules/keycloak/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import { EndpointSecurity } from '@raincatcher/express-auth';
 import * as express from 'express';
 import * as session from 'express-session';

--- a/demo/server/src/modules/passport-auth/DemoUserRepository.ts
+++ b/demo/server/src/modules/passport-auth/DemoUserRepository.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import { UserRepository, UserService } from '@raincatcher/auth-passport';
 import * as _ from 'lodash';
 

--- a/demo/server/src/modules/passport-auth/index.ts
+++ b/demo/server/src/modules/passport-auth/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import { PassportAuth, UserRepository, UserService } from '@raincatcher/auth-passport';
 import { getLogger } from '@raincatcher/logger';
 import * as express from 'express';

--- a/demo/server/src/modules/session/RedisSession.ts
+++ b/demo/server/src/modules/session/RedisSession.ts
@@ -2,7 +2,6 @@
  * @module @raincatcher/demo-server
  */
 
-
 import * as connectRedis from 'connect-redis';
 import * as session from 'express-session';
 import appConfig from '../../util/Config';

--- a/demo/server/src/modules/session/RedisSession.ts
+++ b/demo/server/src/modules/session/RedisSession.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 
 import * as connectRedis from 'connect-redis';
 import * as session from 'express-session';

--- a/demo/server/src/modules/wfm-user/StaticUsersRepository.ts
+++ b/demo/server/src/modules/wfm-user/StaticUsersRepository.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import { User, UsersRepository } from '@raincatcher/wfm-user';
 import * as Bluebird from 'bluebird';
 import * as _ from 'lodash';

--- a/demo/server/src/user-routes/index.ts
+++ b/demo/server/src/user-routes/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 'use strict';
 
 import * as express from 'express';

--- a/demo/server/src/util/Config.ts
+++ b/demo/server/src/util/Config.ts
@@ -1,3 +1,7 @@
+/**
+ * @module @raincatcher/demo-server
+ */
+
 import { SyncGlobalParameters } from '@raincatcher/datasync-cloud';
 import { RedisStoreOptions } from 'connect-redis';
 import { SessionOptions } from 'express-session';

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "clean:coverage": "del coverage_report",
     "clean:packages": "lerna run clean",
     "clean:dependencies": "lerna clean --yes",
-    "clean:docs": "del **/**/docs ",
     "publish:prepare": "./scripts/publish-prepare.sh",
     "publish:dry": "npm run publish:prepare && lerna publish --skip-npm --skip-git --canary --yes",
     "publish:test": "./scripts/test-publish.sh",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "opn-cli": "3.1.0",
     "tslint": "5.8.0",
     "typedoc": "0.9.0",
+    "typedoc-plugin-external-module-name": "^1.0.10",
     "typescript": "2.6.1",
     "yargs": "10.0.3"
   }

--- a/scripts/docgen.sh
+++ b/scripts/docgen.sh
@@ -4,9 +4,12 @@
 VERSION=1.1.0
 DOC_FOLDER=docs
 DOCS_LOCATION=${PWD}/$DOC_FOLDER/api
+TYPEDOC=${PWD}/node_modules/.bin/typedoc # Need to use root typedoc to pick up typedoc plugin
+
+rm -rf $DOCS_LOCATION
 
 echo "Generate documentation for packages"
-lerna exec --ignore @raincatcher/demo-server  -- typedoc --mode modules --out $DOCS_LOCATION/\$LERNA_PACKAGE_NAME --excludePrivate --excludeExternals --theme minimal src/
+lerna exec --ignore @raincatcher/demo-server  -- $TYPEDOC --mode file --out $DOCS_LOCATION/\$LERNA_PACKAGE_NAME --excludePrivate --excludeExternals src/
 
 echo "Rename root folder"
 mv $DOCS_LOCATION/@raincatcher $DOCS_LOCATION/$VERSION

--- a/scripts/docgen.sh
+++ b/scripts/docgen.sh
@@ -3,25 +3,12 @@
 
 VERSION=1.1.0
 DOC_FOLDER=docs
-DOCS_LOCATION=$DOC_FOLDER/api
-DOC_PATH=../../$DOCS_LOCATION
-DOCS_BRANCH=api-docs-update-$VERSION
-
-echo "Clean previous docs folders and documentation git repository"
-npm run clean:docs
-
-echo "Cloning docs repository"
-git clone --depth 1 git@github.com:feedhenry-raincatcher/raincatcher-docs.git $DOC_FOLDER
+DOCS_LOCATION=${PWD}/$DOC_FOLDER/api
 
 echo "Generate documentation for packages"
-lerna exec --ignore @raincatcher/demo-server  -- typedoc --out docs/ --excludePrivate --excludeExternals --theme minimal
-
-echo "Copy documentation"
-lerna exec --ignore @raincatcher/demo-server --  mkdir -p $DOC_PATH/\$LERNA_PACKAGE_NAME
-lerna exec --ignore @raincatcher/demo-server --  cp -Rf ./docs $DOC_PATH/\$LERNA_PACKAGE_NAME
+lerna exec --ignore @raincatcher/demo-server  -- typedoc --mode modules --out $DOCS_LOCATION/\$LERNA_PACKAGE_NAME --excludePrivate --excludeExternals --theme minimal src/
 
 echo "Rename root folder"
-cd $DOCS_LOCATION
-mv @raincatcher $VERSION
+mv $DOCS_LOCATION/@raincatcher $DOCS_LOCATION/$VERSION
 
 echo "Documentation was generated. Please continue website relase directly in documentation repository"


### PR DESCRIPTION
## Motivation
Fix API documentation generation script

## Description
- Use single instance of typedoc bin and generate all API documentation to the root folder directly (instead of copying various folders over.)
- Use https://github.com/christopherthielen/typedoc-plugin-external-module-name to group module contents properly together.