### PR TITLE
Readd browserify-shim since it's a hidden dependency of fh-sync-js

### DIFF
--- a/client/datasync-client/package.json
+++ b/client/datasync-client/package.json
@@ -47,6 +47,7 @@
     "sinon": "4.0.1",
     "source-map-support": "0.5.0",
     "ts-node": "3.3.0",
+    "browserify-shim": "3.8.14",
     "typescript": "2.5.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Motivation
fh-sync-js fails to build without the hidden peerDependency of browserify-shim
