### PR TITLE
Bump sync version

### DIFF
--- a/client/datasync-client/package.json
+++ b/client/datasync-client/package.json
@@ -55,7 +55,7 @@
     "@types/lodash": "4.14.73",
     "@raincatcher/logger": "1.1.1",
     "bluebird": "3.5.0",
-    "fh-sync-js": "1.0.3",
+    "fh-sync-js": "1.1.1",
     "lodash": "4.17.4"
   }
 }


### PR DESCRIPTION
## Motivation

Use latest sync version. 
Current version is not sending cuid. 
Latest version has problem with browserify that will be resolved once this PR will be merged:
https://github.com/feedhenry/fh-sync-js/pull/41

ping @darachcawley 